### PR TITLE
Fix factual inaccuracies in redaxo-ycom skills

### DIFF
--- a/plugins/redaxo-ycom/skills/ycom-external-auth/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-external-auth/SKILL.md
@@ -7,9 +7,11 @@ description: External authentication for YCom – SAML, OAuth2, and CAS. Covers 
 
 YCom integrates with three SSO protocols out of the box: SAML, OAuth2, CAS. Each has its own config file, its own value field, and a matching extension point for mapping the external identity to a `rex_ycom_user`.
 
+All three protocols load their config via `rex_addon::get('ycom')->getDataPath('<protocol>.php')`, i.e. from `redaxo/data/addons/ycom/`. The path is identical regardless of REDAXO instance — keep these files **out of git** and version-control only an `.example.php` template.
+
 ## SAML
 
-Config file: `data/addons/ycom/saml.php` — return an array of SAML settings consumed by the underlying SimpleSAMLphp / OneLogin library YCom uses.
+Config file: `redaxo/data/addons/ycom/saml.php` — return an array of SAML settings consumed by the OneLogin/php-saml library YCom bundles.
 
 Login button on a YForm form:
 
@@ -26,7 +28,7 @@ Parameters:
 
 ## OAuth2
 
-Config file: `data/addons/ycom/oauth2.php` — return a settings array consumed by the underlying OAuth2 client.
+Config file: `redaxo/data/addons/ycom/oauth2.php` — return a settings array consumed by `league/oauth2-client`'s `GenericProvider`.
 
 ```php
 <?php
@@ -51,7 +53,7 @@ Same parameter shape as SAML.
 
 ## CAS
 
-Config file: `data/addons/ycom/cas.php` — settings for the CAS server.
+Config file: `redaxo/data/addons/ycom/cas.php` — settings for the CAS server. The CAS server CA cert lives next to it at `redaxo/data/addons/ycom/cas_cert.pem`.
 
 ```
 ycom_auth_cas|CAS Login|Fehler bei CAS-Login|example.com|{"status":1}

--- a/plugins/redaxo-ycom/skills/ycom-otp/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-otp/SKILL.md
@@ -70,15 +70,15 @@ The injection is part of the standard auth flow — you don't need to call it ma
 When some user roles shouldn't go through OTP:
 
 ```php
-rex_extension::register('YCOM_AUTH_INIT', function (rex_extension_point $ep) {
-    $user = rex_ycom_auth::getUser();
-    if ($user && $user->isInGroup($apiOnlyGroupId)) {
-        rex_ycom_auth::setSessionVar('otp_verified', true);
+rex_extension::register('YCOM_AUTH_LOGIN_SUCCESS', function (rex_extension_point $ep) {
+    $user = $ep->getSubject();
+    if ($user instanceof rex_ycom_user && $user->isInGroup($apiOnlyGroupId)) {
+        rex_ycom_user_session::getInstance()->setOTPverified($user);
     }
 });
 ```
 
-Setting `otp_verified=true` in the session bypasses the OTP injection for that session.
+The OTP injection reads `otp_verified` from the **DB session row** (`rex_ycom_user_session`), not from `$_SESSION`. Use `setOTPverified()` to mark the current session as verified — `rex_ycom_auth::setSessionVar('otp_verified', true)` does NOT bypass the injection.
 
 ## Common pitfalls
 

--- a/plugins/redaxo-ycom/skills/ycom-overview/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-overview/SKILL.md
@@ -129,10 +129,16 @@ if (rex_ycom_auth::getUser()) { /* logged in */ }
 $article = rex_article::get($id);
 rex_ycom_auth::articleIsPermitted($article); // bool
 
-// Programmatic login (e.g. after a custom registration step)
-rex_ycom_auth::loginWithParams(['login' => $userId]);
+// Programmatic login (e.g. after a custom registration step).
+// Each key/value becomes a YOrm where() clause — use real columns,
+// not magic names. `login` is a string column, NOT a user id.
+rex_ycom_auth::loginWithParams(['id' => $userId]);
+rex_ycom_auth::loginWithParams(['email' => $email]);
 
-// Logout
+// Logout (writes log entry, clears stay-logged-in cookie, clears session)
+rex_ycom_auth::logout($user);
+
+// Low-level: clear session only (no log entry, no cookie cleanup)
 rex_ycom_auth::clearUserSession();
 
 // Session variables
@@ -230,4 +236,6 @@ Set via `auth_rule` in YCom settings.
 - Reading status with `==` against `STATUS_REQUESTED` (0) without checking for false-positives — `null == 0` is true in loose comparison. Use `===` or constants.
 - Forgetting that `articleIsPermitted()` doesn't redirect on its own — it just returns bool. The redirect happens inside `rex_ycom_auth::init()`.
 - Hardcoding article IDs in templates — always pull from `rex_ycom_config::get('article_id_login')` etc., so the editor can change them in the backend.
-- Calling `loginWithParams(['login' => $userId])` from a context where the response was already sent — login sets headers, must run before output.
+- Calling `loginWithParams()` from a context where the response was already sent — login sets headers (cookie + redirect), must run before output.
+- Passing a user id as `['login' => $userId]` to `loginWithParams()` — `login` is the string login name, not the id. Use `['id' => $userId]` or `['email' => $email]`.
+- Using `clearUserSession()` as the user-facing logout — it skips the log entry and stay-logged-in cookie cleanup. Use `rex_ycom_auth::logout($user)` for the full flow.

--- a/plugins/redaxo-ycom/skills/ycom-permissions/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-permissions/SKILL.md
@@ -74,9 +74,12 @@ foreach ($user->getRelatedCollection('ycom_groups') as $group) {
 ```php
 $user = rex_ycom_auth::getUser();
 if ($user) {
+    // getRelatedDataset returns the FIRST related group only — fine when each
+    // user has exactly one group. For multi-group users, iterate the collection
+    // and pick the highest-priority target instead.
     $group = $user->getRelatedDataset('ycom_groups');
     if ($group) {
-        $target = $group->getValue('target_id'); // custom be_link field on the group table
+        $target = (int) $group->getValue('target_id'); // custom be_link field on the group table
         if ($target) {
             rex_response::sendRedirect(rex_getUrl($target));
         }
@@ -84,7 +87,17 @@ if ($user) {
 }
 ```
 
-Add a `target_id` field (type `be_link`) to the YCom group table so editors can configure where each group lands after login.
+Add a `target_id` field (type `be_link`) to the YCom group table so editors can configure where each group lands after login. Multi-group example:
+
+```php
+foreach ($user->getRelatedCollection('ycom_groups') as $group) {
+    $target = (int) $group->getValue('target_id');
+    if ($target) {
+        rex_response::sendRedirect(rex_getUrl($target));
+        return;
+    }
+}
+```
 
 ### Extending article permission UI
 

--- a/plugins/redaxo-ycom/skills/ycom-tokens/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-tokens/SKILL.md
@@ -77,12 +77,18 @@ After validation, render the password-change form (see the `ycom-forms` skill) �
 ## Registration via token
 
 ```
-ycom_user_token|token|create|register|
 text|email|E-Mail
+validate|type|email|email|Bitte gueltige E-Mail eingeben.
+validate|unique|email|E-Mail wird bereits verwendet.|rex_ycom_user
 ycom_auth_password|password|Passwort|...
+hidden|status|0
+action|copy_value|email|login
 action|db|rex_ycom_user
+ycom_user_token|token|create|register|email
 action|tpl2email|register_confirm|email|
 ```
+
+Important: the form **must contain a field literally named `email`**. The `create` branch of `ycom_user_token` reads from `value_pool['sql']['email']` directly — the fourth pipe slot is documented as `email_field` for clarity but is not evaluated by the current implementation. So: name the email field `email`, full stop.
 
 Confirmation:
 
@@ -96,7 +102,7 @@ This pattern is cleaner than the older `activation_key` approach (see `ycom-form
 
 ## Common pitfalls
 
-- Using `ycom_user_token|token|create` without an `email_field` parameter – then the token has no associated user, and validation never matches.
+- The form lacks a field literally named `email` – the `create` branch reads `value_pool['sql']['email']` and throws `email not found`. The fourth pipe slot is a documentation hint, not a configurable field selector.
 - Building the link URL with `rex_getUrl()` but forgetting the article ID matches the article that has the `validate` field – wrong target = `Token ungueltig`.
 - Setting `csrf_protection|1` (default) on the validation article – the email link can't carry a CSRF token, so always add `objparams|csrf_protection|0` on validation forms.
 - Using a `login`-type token to also reset the password – use `password_reset` type. `login` only logs in.


### PR DESCRIPTION
## Summary

Audited the seven `redaxo-ycom` skill files against the actual YCom 4.4.4 source (`yakamara/redaxo_ycom`) and corrected guidance that would lead users astray. Five files touched, no new files, no scope creep — purely correctness fixes.

## What changed

- **ycom-otp** — bypass example used `setSessionVar('otp_verified', true)`, but the OTP injection reads the flag from the `rex_ycom_user_session` DB row (`getCurrentSession()`), not from `$_SESSION`. Replaced with `rex_ycom_user_session::getInstance()->setOTPverified(\$user)`. Also switched the EP from `YCOM_AUTH_INIT` (fires every request) to `YCOM_AUTH_LOGIN_SUCCESS` (fires once at login, with the user as subject).
- **ycom-overview** — `loginWithParams` example was `['login' => \$userId]`, but `login` is a string login name, not an id. The method builds YOrm `where()` clauses from each key/value, so use `['id' => …]` or `['email' => …]`. Also added `rex_ycom_auth::logout(\$user)` as the proper user-facing logout (writes log, clears stay-logged-in cookie, clears session) — `clearUserSession()` is the low-level step. Three matching pitfall entries added.
- **ycom-tokens** — registration recipe had `ycom_user_token|token|create|register|` (empty 4th slot) and contradicted the file's own pitfall. Reordered the recipe to a working sequence and documented the actual implementation: the `create` branch reads `value_pool['sql']['email']` directly, so the form **must** contain a field literally named `email`. The fourth pipe slot is a documentation hint and is not evaluated.
- **ycom-external-auth** — config-file paths clarified to `redaxo/data/addons/ycom/<protocol>.php` (matches `rex_addon::get('ycom')->getDataPath()`). Also named the actual OAuth2 library (`league/oauth2-client` + `GenericProvider`) and pointed at the CAS cert location (`cas_cert.pem` next to `cas.php`).
- **ycom-permissions** — group-redirect example used `\$user->getRelatedDataset('ycom_groups')`, which returns only the **first** related group. Added a caveat for multi-group users plus a `getRelatedCollection()` example that iterates and picks the first non-empty target.

## Test plan

- [x] All API methods used in the new examples verified against current source (`grep -nE "public (static )?function"` over `lib/`, `plugins/auth/lib/`, `plugins/group/lib/`, `plugins/media_auth/lib/`)
- [x] All extension-point names verified against `registerPoint()` call sites
- [x] OTP bypass: read `injections/otp.php:23` to confirm the flag is read from `getCurrentSession($user)['otp_verified']`, not `$_SESSION`
- [x] Token field flow: read `value/ycom_user_token.php` `enterObject()` + `preAction()` to confirm `email` is hardcoded and the 4th pipe slot is unused on `create`
- [x] Config-file paths: read `lib/yform/trait_value_auth_extern.php` to confirm `getDataPath()` resolves to `redaxo/data/addons/ycom/`
- [ ] Reviewer sanity-check on the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)