### PR TITLE
feat(marketplace): add redaxo-multiglossar plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     "email": "info@redaxo.org"
   },
   "metadata": {
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
@@ -92,6 +92,18 @@
         "name": "Friends Of REDAXO"
       },
       "homepage": "https://github.com/FriendsOfREDAXO/search_it",
+      "license": "MIT"
+    },
+    {
+      "name": "redaxo-multiglossar",
+      "source": "./plugins/redaxo-multiglossar",
+      "description": "MultiGlossar addon: multilingual glossary terms, frontend term replacement, tooltips/links, article and template exclusions",
+      "category": "cms",
+      "tags": ["redaxo", "multiglossar", "glossary", "tooltip", "multilingual"],
+      "author": {
+        "name": "Friends Of REDAXO"
+      },
+      "homepage": "https://github.com/FriendsOfREDAXO/multiglossar",
       "license": "MIT"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -24,18 +24,20 @@ Add addon-specific plugins based on what your project uses:
 /plugin install redaxo-yform@redaxo-marketplace
 /plugin install redaxo-yrewrite@redaxo-marketplace
 /plugin install redaxo-structure@redaxo-marketplace
+/plugin install redaxo-multiglossar@redaxo-marketplace
 ```
 
 ## Available Plugins
 
-| Plugin | What it covers | When to install |
-|---|---|---|
-| `redaxo-core` | Architecture, modules, templates, `rex_sql`, extension points, addon development, console commands, `rex_api_function`, metainfo fields | Every REDAXO project |
-| `redaxo-structure` | Articles, categories, content editing, meta info | Almost always (Structure is part of core) |
-| `redaxo-yform` | YForm tables, datasets (YOrm), field/validate/action reference, frontend forms, email templates, REST API | If `yform` is installed |
-| `redaxo-yrewrite` | Domains, pretty URLs, redirects, multi-language SEO | If `yrewrite` is installed |
-| `redaxo-ycom` | Frontend user auth, login/registration/password forms, groups, media protection, OTP/2FA, tokens, SAML/OAuth2/CAS | If `ycom` is installed |
-| `redaxo-api-addon` | FriendsOfRedaxo/api – Bearer-token REST API for articles/categories/slices/modules/templates/media | If you call (or extend) the `api` addon |
+| Plugin                | What it covers                                                                                                                          | When to install                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `redaxo-core`         | Architecture, modules, templates, `rex_sql`, extension points, addon development, console commands, `rex_api_function`, metainfo fields | Every REDAXO project                      |
+| `redaxo-structure`    | Articles, categories, content editing, meta info                                                                                        | Almost always (Structure is part of core) |
+| `redaxo-yform`        | YForm tables, datasets (YOrm), field/validate/action reference, frontend forms, email templates, REST API                               | If `yform` is installed                   |
+| `redaxo-yrewrite`     | Domains, pretty URLs, redirects, multi-language SEO                                                                                     | If `yrewrite` is installed                |
+| `redaxo-ycom`         | Frontend user auth, login/registration/password forms, groups, media protection, OTP/2FA, tokens, SAML/OAuth2/CAS                       | If `ycom` is installed                    |
+| `redaxo-api-addon`    | FriendsOfRedaxo/api – Bearer-token REST API for articles/categories/slices/modules/templates/media                                      | If you call (or extend) the `api` addon   |
+| `redaxo-multiglossar` | MultiGlossar term management, multilingual glossary content, DOM-based frontend replacement, tooltip/link output, exclusion rules       | If `multiglossar` is installed            |
 
 ## How it works
 

--- a/plugins/redaxo-multiglossar/.claude-plugin/plugin.json
+++ b/plugins/redaxo-multiglossar/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "redaxo-multiglossar",
+  "version": "0.1.0",
+  "description": "MultiGlossar addon support for Claude Code: glossary terms, multilingual maintenance, parser configuration, and frontend replacement output",
+  "author": {
+    "name": "Friends Of REDAXO"
+  },
+  "homepage": "https://github.com/FriendsOfREDAXO/multiglossar",
+  "repository": "https://github.com/FriendsOfREDAXO/claude-marketplace",
+  "license": "MIT",
+  "keywords": ["redaxo", "multiglossar", "glossary", "tooltip", "multilingual"]
+}

--- a/plugins/redaxo-multiglossar/README.md
+++ b/plugins/redaxo-multiglossar/README.md
@@ -1,0 +1,17 @@
+# redaxo-multiglossar
+
+Claude Code support for [MultiGlossar](https://github.com/FriendsOfREDAXO/multiglossar), the REDAXO addon for centralized glossary terms with automatic frontend replacement (tooltip/link output).
+
+## Skills
+
+- **multiglossar-content-management** - glossary data model, backend workflows, multilingual behavior, and editor permissions
+- **multiglossar-replacement-engine** - `OUTPUT_FILTER` integration, DOM-based replacement, URL resolution, and replacement template placeholders
+- **multiglossar-configuration-exclusions** - settings for start/end scope, ignored tags/classes, excluded articles/templates/metainfo, and cache behavior
+
+## Install
+
+```bash
+/plugin install redaxo-multiglossar@redaxo-marketplace
+```
+
+Use this plugin if your project has the `multiglossar` addon installed and you want implementation help for glossary term management, replacement behavior, and frontend integration.

--- a/plugins/redaxo-multiglossar/skills/multiglossar-configuration-exclusions/SKILL.md
+++ b/plugins/redaxo-multiglossar/skills/multiglossar-configuration-exclusions/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: multiglossar-configuration-exclusions
+description: MultiGlossar configuration and exclusion rules - glossar_starttag/glossar_endtag scope selection, glossar_ignoretags with tag/class locks, article/template/metainfo exclusion settings, cache and turbocache options, and yrewrite/domain-specific glossary article mapping (article_<domainId>). Use when the user configures where replacements happen or why certain pages/articles must be skipped.
+---
+
+# MultiGlossar Configuration and Exclusions
+
+MultiGlossar behavior is mostly controlled through addon settings. Correct configuration is essential to avoid over-replacement or performance issues.
+
+## Scope configuration (start/end tags)
+
+Replacement is applied only within one configured document segment:
+
+- `glossar_starttag` - regex/string for start marker (default around `<body.*?>`)
+- `glossar_endtag` - regex/string for end marker (default `</body>`)
+
+Projects can use explicit HTML comments in templates (for example `<!--glossar_start-->` and `<!--glossar_stop-->`) and configure these markers in settings.
+
+Only one unique scope is expected. Ambiguous patterns can lead to missing replacements.
+
+## Ignored tags and classes
+
+MultiGlossar has built-in ignored elements (for example `a`, `h1`-`h6`, `figcaption`, `script`, `style`, `svg`, `dfn`, `exclude`).
+
+Additional excludes can be set via `glossar_ignoretags`:
+
+- tag names, e.g. `nav,aside,ul`
+- class selectors with dot prefix, e.g. `.no-glossary,.teaser`
+
+During recursion, matching tags/classes are locked and skipped.
+
+## Article-level exclusions
+
+Typical exclusion controls in `boot.php` include:
+
+- current article is REDAXO notfound article -> always skip
+- `articles_exclude` list (comma-separated article IDs)
+- `exclude_by_template` (template ID list)
+- `exclude_by_meta_field` + `exclude_by_meta_condition` (`<0`, `=0`, `>0`)
+
+This is useful for legal pages, forms, and technical pages where glossary links are undesirable.
+
+## Multi-domain and YRewrite
+
+If YRewrite is active, MultiGlossar can use domain-specific glossary article assignment:
+
+- settings like `article_<domainId>` map each domain to its glossary article
+- without YRewrite, fallback is generic `article`
+
+Editorial term storage is not domain-separated; only output linking/context can differ by domain.
+
+## Cache behavior
+
+Important options:
+
+- `use_cache` - use MultiGlossar output cache
+- `use_turbocache` - read cached replacement early (`PACKAGES_INCLUDED`)
+
+Cache invalidation hooks are bound to article/category/slice events and glossary form saves. When integrating custom import/update scripts, clear or refresh caches accordingly.
+
+## Practical setup pattern
+
+1. Define a narrow replacement scope around article content.
+2. Add ignore tags/classes for navigation, UI components, and structured widgets.
+3. Exclude legal/system pages by article ID or metainfo rule.
+4. Validate per language and per domain.
+5. Enable cache after functional behavior is confirmed.
+
+## Common pitfalls
+
+- Using too broad start/end patterns, replacing content in headers/menus accidentally.
+- Forgetting to exclude interactive UI containers, causing tooltip markup conflicts.
+- Mixing article IDs from different environments without checking production IDs.
+- Using metainfo exclusion with the wrong condition operator (`<0`, `=0`, `>0`).
+- Enabling cache during debugging and interpreting stale HTML as parser failure.

--- a/plugins/redaxo-multiglossar/skills/multiglossar-content-management/SKILL.md
+++ b/plugins/redaxo-multiglossar/skills/multiglossar-content-management/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: multiglossar-content-management
+description: MultiGlossar backend data management - creating terms and term_alt aliases, activating/deactivating terms, multi-language behavior with clang tabs, and editor permissions. Use when the user works with pages/main.php, rex_multiglossar records, clang-specific glossary entries, or asks how terms are maintained across languages.
+---
+
+# MultiGlossar Content Management
+
+MultiGlossar stores glossary terms in `rex_multiglossar` and lets editors maintain central definitions that are injected into frontend content.
+
+## Core data model
+
+Typical fields in glossary records:
+
+- `pid` - shared logical term ID across languages
+- `clang_id` - language assignment
+- `term` - main glossary term
+- `term_alt` - additional terms/aliases (newline-separated)
+- `definition` - short definition text used in replacement output
+- `active` - whether the term is currently used for replacement
+- `casesensitive` - case-sensitive matching toggle
+
+A term is conceptually language-grouped by `pid`, while language-specific content is held per `clang_id` row.
+
+## Backend workflow
+
+In `multiglossar/main`, editors usually:
+
+- add a new term (initially disabled by default)
+- enter definition and optional aliases in `term_alt`
+- activate/deactivate terms depending on release state
+- sort/search rows for maintenance
+
+Because replacements run in frontend output, even small text changes should be treated as content release changes.
+
+## Multi-language behavior
+
+MultiGlossar is designed for multi-language REDAXO setups:
+
+- New terms are created for all languages.
+- Deleting a term removes all language variants of that term.
+- If a language is added later, terms from the start language are copied and set inactive.
+- If a language is deleted, related glossary rows are removed.
+
+This means editors should coordinate glossary activation per language, especially on partially translated projects.
+
+## Permissions and editorial governance
+
+By convention in MultiGlossar:
+
+- Add/delete actions are restricted to admins or users with broad language permissions.
+- Translators without global language permissions should focus on content updates, not structure changes.
+
+When implementing custom backend tooling, keep these permission boundaries aligned with `rex::getUser()` and clang permissions.
+
+## Integration with glossary article/detail page
+
+Many projects use one dedicated glossary article as detail target, while in-text replacements remain inline tooltip/help markers. Ensure all terms link consistently to the chosen glossary article structure.
+
+## Common pitfalls
+
+- Treating one language row as fully independent: rows are linked by `pid`, so structural actions affect all languages.
+- Storing multiple aliases comma-separated instead of newline-separated in `term_alt`, which can break expected matching behavior.
+- Activating copied fallback entries for new languages too early before translations are ready.
+- Allowing unrestricted delete access for editors, causing cross-language data loss.

--- a/plugins/redaxo-multiglossar/skills/multiglossar-replacement-engine/SKILL.md
+++ b/plugins/redaxo-multiglossar/skills/multiglossar-replacement-engine/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: multiglossar-replacement-engine
+description: MultiGlossar replacement engine internals - boot.php OUTPUT_FILTER hook, MultiGlossar\\Parser in lib/glossar/multiglossar.php, DOMDocument parsing, text_replace regex matching, replace_definition template placeholders, and URL namespace resolution via Url\\Profile/url_generator_profile. Use when the user debugs missing replacements, broken tooltip HTML, URL addon integration, or replacement performance.
+---
+
+# MultiGlossar Replacement Engine
+
+Frontend replacement is executed in `boot.php` via `rex_extension::register('OUTPUT_FILTER', ...)` and delegated to `MultiGlossar\\Parser` (`lib/glossar/multiglossar.php`).
+
+## Runtime flow
+
+1. `OUTPUT_FILTER` receives the rendered page HTML.
+2. MultiGlossar checks exclusion rules (error article, excluded IDs/templates/meta condition).
+3. Optional cache read happens before parsing.
+4. Parser initializes DOM and glossary data for current `clang_id`.
+5. Text nodes are traversed and terms are replaced with configured output HTML.
+6. Header/footer and exclude markers are restored.
+
+This architecture avoids raw global string replacement and limits changes to parsed text nodes.
+
+## Parser and DOM behavior
+
+Key parser methods:
+
+- `init_dom($source)` - detects configured start/end scope, loads glossary rows, initializes ignored tags/classes
+- `parse_dom()` - traverses the DOM and rebuilds final output
+- `parse_childs($node)` - recursive node walk with lock checks
+- `text_replace($content)` - regex-based term matching and replacement token strategy
+
+`<!--exclude-->...<!--endexclude-->` comment pairs are transformed into temporary elements and excluded from matching.
+
+## Matching logic
+
+Replacement behavior includes:
+
+- aliases from `term_alt` are additional searchable markers
+- optional case-sensitive matching (`casesensitive`)
+- per-term replacement control: usually first match only, except for configured `article_complete` IDs where all matches are replaced
+- word-boundary regex matching (`\\b...\\b`) to reduce accidental substring hits
+
+## Output template placeholders
+
+Replacement markup is driven by config `replace_definition`. Supported placeholders include:
+
+- `---DEFINITION---`, `---URL---`, `---TERM---` (escaped variants)
+- `---DEFINITION_RAW---`, `---URL_RAW---`, `---TERM_RAW---` (raw variants)
+
+This enables custom tooltip/link markup without touching PHP code.
+
+## URL addon integration
+
+`resolveUrlKey()` resolves the query key/namespace for glossary detail URLs:
+
+- default fallback: `gloss_id_<clangId>`
+- if URL addon is available, namespace is resolved from `Url\\Profile` or `rex_url_generator_profile`
+
+This is important when URL profiles rewrite parameter names.
+
+## UIkit tooltip normalization
+
+The parser normalizes certain UIkit tooltip patterns so configured output remains valid with dynamic definitions (for example converting direct `data-uk-tooltip` usage to a `uk-tooltip="title: ..."` format when needed).
+
+## Common pitfalls
+
+- Running replacements against raw HTML with custom code instead of using parser hooks, causing broken markup in attributes/tags.
+- Using raw placeholders in output without escaping when values come from editor content.
+- Forgetting URL namespace/profile handling, resulting in broken glossary detail links.
+- Expecting replacements inside ignored elements (`a`, headings, `script`, `style`, configured classes/tags).
+- Debugging only with one language while issues are actually `clang_id` specific.


### PR DESCRIPTION
Dieses PR ergänzt den REDAXO Claude Marketplace um ein neues Plugin redaxo-multiglossar für das Addon MultiGlossar. Enthalten sind drei fokussierte Skills für redaktionelle Glossar-Pflege, technische Ersetzungslogik (Parser/OUTPUT_FILTER) sowie Konfiguration und Ausschlussregeln inkl. Cache-/Domain-Kontext. 

Zusätzlich wurde das Plugin in marketplace.json registriert, die Marketplace-Version auf 0.3.0 erhöht und die Root-README um Install-Hinweis und Plugin-Übersicht erweitert. Es wurden ausschließlich Marketplace-Inhalte (Markdown/JSON) geändert, keine Runtime-Änderungen am Addon selbst.