### PR TITLE
Update redaxo-api-addon plugin for api-addon 1.2

### DIFF
--- a/plugins/redaxo-api-addon/.claude-plugin/plugin.json
+++ b/plugins/redaxo-api-addon/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "redaxo-api-addon",
-  "version": "0.1.0",
-  "description": "Support for the FriendsOfRedaxo/api addon: bearer-token REST API for articles, categories, slices, modules, templates, languages, media, and users",
+  "version": "0.2.0",
+  "description": "Support for the FriendsOfRedaxo/api addon (v1.2+): Bearer-token + backend-session REST API for articles, categories, slices, modules, templates, languages, media (incl. multipart upload), users, roles, and metainfo fields/values",
   "author": {
     "name": "Friends Of REDAXO"
   },

--- a/plugins/redaxo-api-addon/README.md
+++ b/plugins/redaxo-api-addon/README.md
@@ -1,11 +1,13 @@
 # redaxo-api-addon
 
-Claude Code support for the [FriendsOfRedaxo/api](https://github.com/FriendsOfRedaxo/api) addon — a Bearer-token-based REST API for REDAXO. Use it to create/read/modify articles, categories, slices, modules, templates, languages, media, and users over HTTP.
+Claude Code support for the [FriendsOfRedaxo/api](https://github.com/FriendsOfRedaxo/api) addon — a Bearer-token + backend-session REST API for REDAXO. Use it to create/read/modify articles, categories, slices, modules, templates, languages, media (incl. multipart upload), users, roles, and metainfo over HTTP.
+
+Tracks the addon's `1.2+` release.
 
 ## Skills
 
-- **api-routes** – authentication, the route table (incl. trailing-slash gotchas), the slice POST schema, OpenAPI spec, and a diagnostic flowchart for 401 / 404 / 500 responses
-- **api-extending** – building your own `RoutePackage` to expose custom endpoints, scope registration, and request-context caveats
+- **api-routes** – Bearer + Backend-Session auth, the full route table (Structure, Templates, Modules, Clangs, Media, Users/Roles, Metainfo, Backend-mirror under `/api/backend/...`), the unified `{data, meta}` list format, the slice POST schema, OpenAPI spec, and a diagnostic flowchart for 401 / 404 / 405 / 500 responses.
+- **api-extending** – building your own `RoutePackage` to expose custom endpoints, the `Body`/`query` schema keys, scope registration, the JsonResponse convention, request-context caveats (auth runs in frontend context, `isBackend()` returns `false`, PRE-EPs that call `rex::requireUser()` fail under Bearer), and the addon's exact-mirror-of-core convention.
 
 ## Install
 
@@ -13,4 +15,4 @@ Claude Code support for the [FriendsOfRedaxo/api](https://github.com/FriendsOfRe
 /plugin install redaxo-api-addon@redaxo-marketplace
 ```
 
-The skills assume the `api` addon is installed and a token has been created in **AddOns → API → Token**.
+The skills assume the `api` addon (v1.2 or later) is installed and either a token has been created in **AddOns → API → Token** or the caller is logged into the REDAXO backend (for `/api/backend/...` routes).

--- a/plugins/redaxo-api-addon/skills/api-extending/SKILL.md
+++ b/plugins/redaxo-api-addon/skills/api-extending/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: api-extending
-description: Adding custom REST routes to the FriendsOfRedaxo/api addon from your own addon – building a RoutePackage subclass, registering routes, scope management, and the request-context caveats (auth runs in frontend context, isBackend() returns false). Use when the user adds endpoints to the api addon, exposes their own data over the same auth/scope mechanism, or runs into "EP fires only in backend but I need it from the API" problems.
+description: Adding custom REST routes to the FriendsOfRedaxo/api addon (v1.2+) from your own addon — building a RoutePackage subclass, registering routes, scope management, the `Body`/`query` schema keys, request-context caveats (auth runs in frontend context, isBackend() returns false, PRE-EPs that call rex::requireUser() fail under Bearer), and the addon's exact-mirror-of-core convention. Use when the user adds endpoints to the api addon, exposes their own data over the same auth/scope mechanism, or runs into "EP fires only in backend but I need it from the API" / "rex::requireUser threw" problems.
 ---
 
-# Extending the `api` Addon
+# Extending the `api` Addon (v1.2+)
 
-You can add your own routes to the `api` addon from any custom addon. They reuse the same Bearer token, the same scope mechanism, and the same OpenAPI generator as the built-in routes.
+You can add your own routes to the `api` addon from any custom addon. They reuse the same Bearer token, the same scope mechanism, the same OpenAPI generator, and the same `JsonResponse`-based response convention as the built-in routes.
 
 ## RoutePackage skeleton
 
@@ -16,6 +16,8 @@ namespace MyVendor\MyAddon\RoutePackage;
 use FriendsOfRedaxo\Api\Auth\BearerAuth;
 use FriendsOfRedaxo\Api\RouteCollection;
 use FriendsOfRedaxo\Api\RoutePackage;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Route;
 
 class MyResource extends RoutePackage
@@ -26,24 +28,65 @@ class MyResource extends RoutePackage
             'myaddon/things/list',                          // becomes the token scope name
             new Route(
                 'myaddon/things',                            // → /api/myaddon/things
-                ['_controller' => self::class . '::handleList', 'query' => [/* schema */]],
+                [
+                    '_controller' => self::class . '::handleList',
+                    'query' => [                             // GET parameter schema
+                        'page'     => ['type' => 'integer', 'default' => 1],
+                        'per_page' => ['type' => 'integer', 'default' => 20],
+                        'sort'     => ['type' => 'string'],
+                        'filter'   => ['type' => 'object', 'properties' => [
+                            'name' => ['type' => 'string'],
+                        ]],
+                    ],
+                ],
                 [], [], '', [], ['GET'],
             ),
             'List things',                                   // OpenAPI summary
-            null,                                            // OpenAPI description
+            null,                                            // custom response definitions, or null
+            new BearerAuth(),
+        );
+
+        RouteCollection::registerRoute(
+            'myaddon/things/add',
+            new Route(
+                'myaddon/things',
+                [
+                    '_controller' => self::class . '::handleAdd',
+                    'Body' => [                              // POST/PUT body schema (note the capital B)
+                        'name'  => ['type' => 'string', 'required' => true],
+                        'color' => ['type' => 'string', 'default' => 'blue'],
+                    ],
+                ],
+                [], [], '', [], ['POST'],
+            ),
+            'Create a thing',
+            null,
             new BearerAuth(),
         );
     }
 
-    public static function handleList($Parameter): \Symfony\Component\HttpFoundation\Response
+    public static function handleList($Parameter): Response
     {
+        $Query = RouteCollection::getQuerySet($_REQUEST, $Parameter['query']);
         // ... build response data ...
-        return new \Symfony\Component\HttpFoundation\Response(json_encode([
-            'data' => [/* ... */],
-        ]));
+        return new JsonResponse(['data' => [/* ... */], 'meta' => [/* ... */]]);
+    }
+
+    public static function handleAdd($Parameter): Response
+    {
+        $Body = json_decode(\rex::getRequest()->getContent(), true);
+        try {
+            $Data = RouteCollection::getQuerySet($Body, $Parameter['Body']);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Body field: `' . $e->getMessage() . '` is required'], 400);
+        }
+        // ... persist ...
+        return new JsonResponse(['data' => [/* created */]], 201);
     }
 }
 ```
+
+Both `query` and `Body` are validated/normalized by `RouteCollection::getQuerySet()` against the schema you declared on the route — don't re-validate manually.
 
 ## Register in the addon's `boot.php`
 
@@ -55,12 +98,11 @@ class MyResource extends RoutePackage
 
 After registration, the new scope (`myaddon/things/list`) appears in the backend token editor. Add it to the relevant token, otherwise calls return `Authorization failed`.
 
-## Trailing-slash decision
+## Trailing-slash convention
 
-Stay consistent: pick either trailing-slash or no-trailing-slash per resource and keep all methods on that resource using the same convention. The built-in addon mixed it up; don't replicate that mistake.
+Stay consistent: pick either trailing-slash or no-trailing-slash per resource and keep all methods on that resource using the same convention. The built-in routes converged on **no trailing slash** in v1.2 — recommend the same in your own RoutePackages:
 
 ```php
-// Recommended: no trailing slash for all methods on /things
 'myaddon/things'         // GET   → list
 'myaddon/things'         // POST  → create
 'myaddon/things/{id}'    // GET   → show
@@ -76,60 +118,63 @@ Stay consistent: pick either trailing-slash or no-trailing-slash per resource an
 | `BackendUser` | Routes that should only be callable when logged into the backend (cookie session) |
 | `null` | Unauthenticated public endpoint — only do this for actually public data |
 
-Prefer `BearerAuth` even for "internal" endpoints. The token + scope mechanism beats IP allowlists for auditability.
+Prefer `BearerAuth` for external-facing endpoints. For internal backend tools, mirror your Bearer routes under `backend/<scope>` with `BackendUser` auth — that's the convention used by the built-in `Backend/*` packages, see `lib/RoutePackage/Backend/Clangs.php` for a tiny reference implementation that clones every Bearer route from a parent package and re-registers it with `BackendUser`.
 
 ## Request context caveats
 
-`RouteCollection::handle()` runs in the **frontend user context**. Two consequences:
+`RouteCollection::handle()` runs in the **frontend user context** (specifically: it dispatches inside `YREWRITE_PREPARE`, before any backend bootstrapping). Three consequences:
 
-- Extension points registered only in `rex::isBackend()` branches **don't fire**. If your addon has hooks registered like `if (rex::isBackend()) { rex_extension::register(...) }`, those hooks are silent for API calls. Either register them unconditionally and guard inside the callback, or trigger them explicitly inside the API route.
-- `rex_request::isBackend()` returns `false` in API calls.
+1. **`rex::isBackend()` returns `false`** in API calls — even on `BackendUser` routes. Code paths gated on `rex::isBackend()` silently skip.
+2. **Extension points registered only in `if (rex::isBackend()) { ... }` branches don't fire.** Either register them unconditionally and guard inside the callback, or trigger them explicitly inside the API route.
+3. **`rex::getUser()` is `null` on Bearer routes.** Some REDAXO PRE-extension-points (notably `SLICE_UPDATE`, `SLICE_DELETE`, parts of structure-management) call `rex::requireUser()` internally. Calling those service methods from an API route that authenticated via Bearer will throw. Two options:
+   - Guard the EP yourself: only call the service method or fire the EP when `rex::getUser() !== null` (i.e. only on `BackendUser` routes).
+   - Bypass the service and replicate the relevant SQL + the POST-EP yourself, the way the built-in `Structure::handleUpdateArticleSlice` / `handleDeleteArticleSlice` do.
 
-When porting backend logic to an API endpoint, audit every `rex::isBackend()` and `rex::getUser()` check in the call path — backend admin permissions don't apply.
+When porting backend logic to an API endpoint, audit every `rex::isBackend()`, `rex::getUser()`, and `rex::requireUser()` check in the call path.
+
+## Mirror REDAXO-core behaviour exactly
+
+The built-in routes follow a hard rule (see the addon's `CLAUDE.md`): the API is not a parallel system, it's an HTTP frontend for the existing backend pages. If a backend page (`pages/*.php`) calls `rex_article_service::editArticle()` and then fires `STRUCTURE_CONTENT_ARTICLE_UPDATED` and clears `rex_article_cache::delete($id)`, the API route does the same — same calls, same EP names, same parameter keys, same order, same cache invalidation. Don't:
+
+- Invent EPs that core doesn't fire (e.g. don't fire a custom `MY_THING_DELETED` if the equivalent backend page is silent)
+- Add fields to the EP payload that core doesn't set
+- Skip cache invalidation that the backend page does
+
+This rule applies equally to your custom RoutePackages if you're wrapping core resources.
 
 ## Returning the right response shape
 
-For consistency with the built-in routes:
-
-- 200 with a body for successful reads
-- 201 with the created resource for successful creates
-- 204 (empty) for successful deletes
-- 4xx with `{"error": "..."}` for client errors
-- 5xx with `{"error": "..."}` only after logging the underlying exception
-
-Use `\Symfony\Component\HttpFoundation\Response` directly. JSON encoding is your responsibility.
+Use `Symfony\Component\HttpFoundation\JsonResponse` (the built-in routes converged on this in #18). It sets `Content-Type: application/json` automatically and serialises arrays for you:
 
 ```php
-return new \Symfony\Component\HttpFoundation\Response(
-    json_encode(['data' => $items]),
-    200,
-    ['Content-Type' => 'application/json']
-);
+return new JsonResponse(['data' => $items, 'meta' => $meta], 200);
+return new JsonResponse(['data' => $created], 201);
+return new JsonResponse(null, 204);                       // empty body
+return new JsonResponse(['error' => 'Bad request'], 400);
 ```
+
+For consistency with the built-in routes:
+
+- **200** for successful reads
+- **201** with the created resource for successful creates
+- **204** (empty) for successful deletes
+- **4xx** with `{"error": "..."}` for client errors (extra context fields are fine)
+- **5xx** with `{"error": "..."}` only after logging the underlying exception (`RouteCollection` already wraps unhandled throwables with `rex_logger::logException`)
+
+For paginated lists, use `ListHelper::paginate()` / `ListHelper::wrapResponse()` to get the standard `{data, meta}` envelope used by every built-in list endpoint.
 
 ## OpenAPI integration
 
-The addon generates an OpenAPI spec at `?page=api/openapi` from registered routes. The third and fourth arguments to `registerRoute()` (summary + description) feed that generator. Spend a minute writing a meaningful summary — Swagger UI uses it.
+The addon generates an OpenAPI spec at `?page=api/openapi` from registered routes. The third and fourth arguments to `registerRoute()` (description + custom responses) feed that generator. Spend a minute writing a meaningful description — Swagger UI uses it.
 
-Schema for query parameters is passed via the `query` key in `_controller`:
-
-```php
-['_controller' => self::class . '::handleList', 'query' => [
-    'filter' => ['type' => 'object', 'properties' => [
-        'name' => ['type' => 'string'],
-    ]],
-    'page'     => ['type' => 'integer', 'default' => 1],
-    'per_page' => ['type' => 'integer', 'default' => 20],
-]]
-```
-
-The OpenAPI generator mirrors this into the spec.
+The `query` and `Body` schemas you declare in `_controller` are mirrored into the spec automatically — that's why they live in the route definition and not just inside the handler.
 
 ## Common pitfalls
 
-- Forgetting to register the RoutePackage in `boot.php` – the route never appears, calls return 404.
-- Forgetting to add the new scope to the token in the backend – calls return `Authorization failed`.
-- Throwing exceptions in the controller without logging – `RouteCollection::handle()` swallows them into a generic 401 / 500. Always `try { ... } catch (Throwable $e) { rex_logger::logException($e); throw; }` (or return a structured error).
-- Building a controller that calls into code paths gated on `rex::isBackend()` – they silently skip in API context.
-- Using closures in `_controller` instead of `Class::method` references – Symfony's `UrlMatcher` doesn't serialize closures cleanly across the routing layer.
-- Accepting JSON bodies via `$_POST` – read `php://input` instead and `json_decode()` it.
+- Forgetting to register the RoutePackage in `boot.php` — the route never appears, calls return 404 `Route not found`.
+- Forgetting to add the new scope to the token in the backend — calls return 401 `Authorization failed`.
+- Using `new Response(json_encode(...))` and forgetting `Content-Type: application/json` — use `JsonResponse` instead, that's the addon convention since #18.
+- Reading bodies via `$_POST` — JSON bodies aren't in `$_POST`. Use `json_decode(rex::getRequest()->getContent(), true)`.
+- Using closures in `_controller` instead of `Class::method` references — Symfony's `UrlMatcher` doesn't serialize closures cleanly across the routing layer.
+- Calling a service method that internally fires a PRE-EP requiring `rex::getUser()` from a Bearer route — wrap the EP-firing in a `null !== rex::getUser()` guard or replicate the service logic in your handler.
+- Throwing exceptions and assuming the framework will format them — yes, `RouteCollection` catches and logs, but you lose the structured error message. For business-logic errors, return `JsonResponse(['error' => '…'], 4xx)` directly.

--- a/plugins/redaxo-api-addon/skills/api-routes/SKILL.md
+++ b/plugins/redaxo-api-addon/skills/api-routes/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: api-routes
-description: Calling the FriendsOfRedaxo/api REST endpoints – Bearer auth, route table for articles/categories/slices/modules/templates/languages/media/users, the slice POST schema, OpenAPI spec, and a 401/404/500 diagnostic flow. Covers the known trailing-slash quirks, the two different 401 messages and what they mean, the LIMIT-binding bug, the article list `name`-filter bug, and yrewrite cache invalidation. Use when the user calls the api addon over HTTP, hits a confusing 401/404, syncs articles between systems via this API, or builds tooling around it.
+description: Calling the FriendsOfRedaxo/api REST endpoints (v1.2+) — Bearer + Backend-Session auth, the route table for articles/categories/slices/modules/templates/languages/media/users/metainfo, the slice POST schema, OpenAPI spec, the unified `{data, meta}` list format, and a 401/404/405/500 diagnostic flow. Covers the Backend-mirror under `/api/backend/...`, multipart media upload, metainfo values for articles/categories/media/clangs, and yrewrite cache invalidation. Use when the user calls the api addon over HTTP, hits a confusing 401/404/405, syncs articles between systems via this API, or builds tooling around it.
 ---
 
-# REDAXO `api` Addon – Calling the API
+# REDAXO `api` Addon – Calling the API (v1.2+)
 
-The `api` addon (Repo: `FriendsOfRedaxo/api`, Vendor-NS: `FriendsOfRedaxo\Api`) exposes a RESTful API for a REDAXO backend. Bearer-token auth, Symfony `UrlMatcher` routing, mounted at `/api/...` via `YREWRITE_PREPARE`.
+The `api` addon (Repo: `FriendsOfRedaxo/api`, Vendor-NS: `FriendsOfRedaxo\Api`) exposes a RESTful API for a REDAXO backend. Auth via Bearer token *or* backend session cookie, Symfony `UrlMatcher` routing, mounted at `/api/...` via `YREWRITE_PREPARE`.
+
+Canonical reference (always trust over this skill if they disagree): the addon `README.md` and `lib/RoutePackage/*.php`.
 
 ## Activation & auth
 
@@ -14,7 +16,7 @@ The `api` addon (Repo: `FriendsOfRedaxo/api`, Vendor-NS: `FriendsOfRedaxo\Api`) 
 - Auth header: `Authorization: Bearer <token>`
 - Two auth classes:
   - `BearerAuth` — token-based frontend API (default for most routes)
-  - `BackendUser` — uses the REDAXO backend session (cookie); for routes that should only be called from the backend (e.g. backend media picker)
+  - `BackendUser` — uses the REDAXO backend session cookie. Every Bearer route is automatically mirrored under `/api/backend/...` with `BackendUser` auth and a `backend/<scope>` scope name. These routes follow the backend user's REDAXO permissions (admin / structure / media / clang / etc.) — no token needed.
 
 ### Apache: pass through `Authorization`
 
@@ -25,96 +27,109 @@ RewriteCond %{HTTP:Authorization} .
 RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 ```
 
-## Route table
+## Route table (high-level)
 
-Authoritative list lives in the addon's `README.md`. Most-used routes:
+Authoritative list lives in `lib/RoutePackage/*.php` (scopes) and the addon's `README.md` (paths + bodies). High-level overview of what's available in v1.2:
 
-| Method   | Path                                          | Scope (= route name)              |
-|----------|-----------------------------------------------|-----------------------------------|
-| GET      | `/api/structure/articles`                     | `structure/articles/list`         |
-| POST     | `/api/structure/articles/`                    | `structure/articles/add`          |
-| DELETE   | `/api/structure/articles/{id}`                | `structure/articles/delete`       |
-| POST     | `/api/structure/articles/{id}/slices`         | `structure/articles/slices/add`   |
-| POST     | `/api/structure/categories/`                  | `structure/categories/add`        |
-| DELETE   | `/api/structure/categories/{id}`              | `structure/categories/delete`     |
-| GET/POST | `/api/templates`                              | `templates/list` / `templates/add`|
-| GET/POST | `/api/modules`                                | `modules/list` / `modules/add`    |
-| GET/POST | `/api/system/clangs`                          | `system/clangs/list` / `system/clangs/add` |
-| GET      | `/api/users`                                  | `users/list`                      |
-| GET      | `/api/media`                                  | `media/list`                      |
-| GET      | `/api/media/categories`                       | `media/category/list`             |
+### Structure (articles / categories / slices)
 
-## Trailing-slash quirks
+| Method | Path                                                  | Scope                                  |
+|--------|-------------------------------------------------------|----------------------------------------|
+| GET    | `/api/structure/articles`                             | `structure/articles/list`              |
+| GET    | `/api/structure/articles/{id}`                        | `structure/articles/get`               |
+| POST   | `/api/structure/articles`                             | `structure/articles/add`               |
+| PUT    | `/api/structure/articles/{id}`                        | `structure/articles/update`            |
+| DELETE | `/api/structure/articles/{id}`                        | `structure/articles/delete`            |
+| POST   | `/api/structure/categories`                           | `structure/categories/add`             |
+| PUT    | `/api/structure/categories/{id}`                      | `structure/categories/update`          |
+| DELETE | `/api/structure/categories/{id}`                      | `structure/categories/delete`          |
+| GET    | `/api/structure/articles/{id}/slices`                 | `structure/articles/slices/list`       |
+| GET    | `/api/structure/articles/{id}/slices/{slice_id}`      | `structure/articles/slices/get`        |
+| POST   | `/api/structure/articles/{id}/slices`                 | `structure/articles/slices/add`        |
+| PUT    | `/api/structure/articles/{id}/slices/{slice_id}`      | `structure/articles/slices/update`     |
+| DELETE | `/api/structure/articles/{id}/slices/{slice_id}`      | `structure/articles/slices/delete`     |
 
-The addon registers `structure/articles/list` (GET) on `'structure/articles'` (no slash) **and** `structure/articles/add` (POST) on `'structure/articles/'` (with slash). Symfony's `UrlMatcher` is strict, so:
+### Templates / modules / clangs
 
-- **GET** must go **without** trailing slash: `/api/structure/articles`
-- **POST** must go **with** trailing slash: `/api/structure/articles/`
+GET/POST list+add, GET/PUT/DELETE on `{id}` for all three. Scopes: `templates/{list,get,add,update,delete}`, `modules/{list,get,add,update,delete}`, `system/clangs/{list,get,add,update,delete}`.
 
-The wrong variant returns `{"error":"Route with method not found or no access"}` (HTTP 401). That's not an auth problem — the matcher exception is wrapped generically into 401 by `RouteCollection::handle()`. Other endpoints have similar inconsistencies; trust the body schema in the source code over a first-guess URL.
+### Media
 
-## Two 401 messages — diagnostic split
+| Method | Path                                  | Scope                  |
+|--------|---------------------------------------|------------------------|
+| GET    | `/api/media`                          | `media/list`           |
+| POST   | `/api/media` (multipart/form-data)    | `media/add`            |
+| GET    | `/api/media/{filename}/info`          | `media/get`            |
+| GET    | `/api/media/{filename}/file`          | `media/get/file`       |
+| PUT    | `/api/media/{filename}/update`        | `media/update`         |
+| DELETE | `/api/media/{filename}/delete`        | `media/delete`         |
+| GET    | `/api/media/category`                 | `media/category/list`  |
+| POST   | `/api/media/category`                 | `media/category/add`   |
+| PUT    | `/api/media/category/{id}`            | `media/category/update`|
+| DELETE | `/api/media/category/{id}`            | `media/category/delete`|
 
-| Response                                                     | Meaning                                       |
-|--------------------------------------------------------------|-----------------------------------------------|
-| `{"error":"Authorization failed"}`                           | Token is valid, **scope is missing**          |
-| `{"error":"Route with method not found or no access"}`       | Matcher found **no route** (or controller threw) |
+Multipart upload: send the file under field name `file_new` (multipart/form-data); other metadata fields (`title`, `category_id`) sit alongside as form fields.
 
-For "Route with method not found": check path / method / trailing slash against the source in `src/addons/api/lib/RoutePackage/*.php` first, then suspect the token.
+### Users / roles
 
-## Diagnostic quick-path
+User CRUD on `/api/users[/{id}]` (`users/{list,get,add,update,delete}`), role CRUD on `/api/users/roles[/{id}]` (`users/roles/{list,get,add,update,delete,duplicate}`), and user↔role assignment:
 
-1. **Which auth message?**
-   - `Authorization failed` → extend the token's scope list.
-   - `Route with method not found or no access` → check path / method / trailing-slash against the source code, then `tail var/log/system.log` for controller PHP errors.
-2. **HTTP 500?** → controller threw an unhandled exception. Read the log file.
-3. **HTTP 201 but frontend 404?** → yrewrite path cache stale (see below).
-4. **Slice add returns 404 with "Template has no module in such ctype"** → in the backend, check the template's module/ctype assignment.
+- `GET /api/users/{id}/role` → `users/role/list`
+- `POST /api/users/{id}/role/{role_id}` → `users/role/assign`
+- `DELETE /api/users/{id}/role/{role_id}` → `users/role/remove`
 
-## Known bugs (as of v1.1)
+### Metainfo (v1.2+)
 
-### `structure/articles` list — broken `name` filter
+Field definitions and value-roundtrips for the four metainfo prefixes (`art_*`, `cat_*`, `med_*`, `clang_*`):
 
-In `Structure::handleArticleList`:
+- `GET /api/metainfo/types` → `metainfo/types/list`
+- CRUD on `/api/metainfo/fields[/{id}]` → `metainfo/fields/{list,get,add,update,delete}`
+- Per-resource values:
+  - Articles: `GET/PUT /api/structure/articles/{id}/metainfo` → `metainfo/articles/values/{get,update}`
+  - Categories: `GET/PUT /api/structure/categories/{id}/metainfo` → `metainfo/categories/values/{get,update}`
+  - Media: `GET/PUT /api/media/{filename}/metainfo` → `metainfo/media/values/{get,update}`
+  - Clangs: `GET/PUT /api/system/clangs/{id}/metainfo` → `metainfo/clangs/values/{get,update}` (admin-only via Backend-Session)
 
-```php
-if (null !== $Query['filter']['name']) {       // default is '' not null → branch always runs
-    $SqlQueryWhere[':name'] = 'id LIKE :name'; // should be 'name LIKE'
-    $SqlParameters[':name'] = '%' . $Query['filter']['id'] . '%'; // 'id' doesn't exist in filter
+### Backend-mirror routes
+
+Every Bearer route above is also exposed under `/api/backend/<original-path>` with scope `backend/<original-scope>`, authenticated via the REDAXO backend session cookie (no token needed). Permissions follow the user's REDAXO `complexPerm` settings — admins see everything, restricted users only their assigned structures/media-categories/clangs.
+
+Use these for first-party backend tooling (a custom backend page calling its own API, for example) so you don't have to issue a token to your own backend session.
+
+## List response format
+
+All list endpoints return:
+
+```json
+{
+  "data":  [ ... ],
+  "meta":  { "page": 1, "per_page": 20, "total": 137, "total_pages": 7 }
 }
 ```
 
-Consequences:
-- PHP warning `Undefined array key "id"` on every list call
-- SQL ends up `id LIKE '%%'` — matches everything but the filter is broken
-- Workaround: check `'' === $Query['filter']['name']` instead, then `LIKE %name%` on `name`
+Common query parameters on list endpoints:
 
-### `LIMIT` binding
+- `page`, `per_page` — pagination (per_page is capped at 1000)
+- `sort` — comma-separated `field:direction`, e.g. `name:asc,createdate:desc`. Each list endpoint has its own whitelist of allowed sort fields; passing an invalid one returns 400 with the allowed list.
+- `filter[<field>]` — endpoint-specific filters
 
-`rex_sql::factory()->getArray($sql, $params)` binds parameters as strings by default. MySQL doesn't accept `LIMIT 'x', 'y'` in all configurations (especially with `PDO::ATTR_EMULATE_PREPARES=false`). The endpoint then fails with "Route with method not found" (= swallowed exception) even though it's an SQL error.
+## Diagnostic flow (status codes)
 
-Workaround: cast `(int)$start` and `(int)$per_page` and inline them into the SQL string instead of using placeholders.
+| Status | Body                                                                     | Meaning                                                                |
+|--------|--------------------------------------------------------------------------|------------------------------------------------------------------------|
+| 401    | `{"error":"Authorization failed"}`                                       | Bearer auth failed: token invalid, or scope not in token's scope list  |
+| 404    | `{"error":"Route not found"}`                                            | No route matched the path                                              |
+| 405    | `{"error":"Method not allowed","allowed":[...]}`                         | Path matched but the HTTP method is wrong; `allowed` lists valid ones  |
+| 500    | `{"error":"Internal server error","message":"..."}`                      | Controller threw — check `var/log/system.log` for the exception        |
 
-### "Headers already sent"
+Quick path:
 
-`RouteCollection::handle()` calls `JSON_PRETTY_PRINT` for the response, then `rex_response::setStatus()` sets headers. Some configurations emit bytes earlier → log warnings (not functionally broken).
-
-### Frontend visibility — yrewrite path cache
-
-A newly-created article/category may return `404` on the frontend even with `status=1`:
-
-- yrewrite caches URL paths in `var/cache/addon/yrewrite/...`
-- `rex_article_service::addArticle()` triggers the right EPs, but yrewrite doesn't always regenerate its path cache (especially for new root categories)
-- Fix: backend → **AddOns → yrewrite → Allgemein** → "Alle Caches generieren". Or in code: `rex_yrewrite::generatePathFile([])`
-- There is currently **no** API endpoint for cache refresh.
-
-### Article metainfo not settable via API
-
-The article `add` schema knows only base fields (`name`, `category_id`, `priority`, `status`, `template_id`). Custom metainfos (`art_*`, `cat_*`) are not accepted. Workaround: set them via a separate backend step or write SQL directly. PUT/PATCH on articles is in the README as planned but not implemented.
-
-### Media upload not active
-
-`POST /api/media` is marked ❌ in the README. Workaround: place media manually (or via migration) in the media pool, then reference filenames via `media1..media10` when creating slices.
+1. **401 `Authorization failed`** → `BearerAuth`: extend the token's scope list to include the route's scope. `BackendUser` route: log into the backend first.
+2. **404 `Route not found`** → check the path against `lib/RoutePackage/*.php`.
+3. **405 `Method not allowed`** → use one of the methods in `allowed[]`.
+4. **500 `Internal server error`** → `tail var/log/system.log` for the underlying exception. The `message` field also includes the immediate error string.
+5. **HTTP 201 but frontend 404?** → yrewrite path cache stale (see below).
+6. **Slice add returns 4xx / 500 with "Template has no module in such ctype"** → in the backend, check the template's module/ctype assignment.
 
 ## Slice schema
 
@@ -125,7 +140,7 @@ The article `add` schema knows only base fields (`name`, `category_id`, `priorit
   "module_id": <int, required>,
   "clang_id":  <int, required>,
   "ctype_id":  <int, default 1>,
-  "value1":   "...",   "value2":   "...",   ...   "value19":   "...",
+  "value1":   "...",   "value2":   "...",   ...   "value20":   "...",
   "media1":   "...",   ...   "media10":  "...",
   "medialist1":"...", ...   "medialist10":"...",
   "link1":    "...",   ...   "link10":   "...",
@@ -133,14 +148,36 @@ The article `add` schema knows only base fields (`name`, `category_id`, `priorit
 }
 ```
 
-One slice = one module. Which `value*` / `media*` slot maps to which editor field is defined in `src/modules/<name> [id]/input.php` as `REX_INPUT_VALUE[n]` / `REX_MEDIA[id=n]`.
+One slice = one module. Which `value*` / `media*` slot maps to which editor field is defined in the module's input PHP as `REX_INPUT_VALUE[n]` / `REX_MEDIA[id=n]`.
 
 The addon validates before insert:
 
 - Article exists (`rex_article::get(...)`)
 - Language exists (`rex_clang::getAllIds()`)
 - Module exists (`rex_module`)
-- **Module is allowed in the template's ctype** (`rex_template::hasModule(...)`) — otherwise 404. If this check fails, look at the template's ctype/module assignment in the backend.
+- **Module is allowed in the template's ctype** (`rex_template::hasModule(...)`) — otherwise the call fails. If this check fails, look at the template's ctype/module assignment in the backend.
+
+`PUT` on a slice replaces the same fields; `DELETE` removes the slice and triggers the same EP chain as the backend page (`SLICE_DELETE` PRE → `rex_sql` delete → `SLICE_DELETED` POST → `art_content_updated`).
+
+## Frontend visibility — yrewrite path cache
+
+A newly-created article/category may return `404` on the frontend even with `status=1`:
+
+- yrewrite caches URL paths in `var/cache/addon/yrewrite/...`
+- `rex_article_service::addArticle()` triggers the right EPs, but yrewrite doesn't always regenerate its path cache (especially for new root categories)
+- Fix: backend → **AddOns → yrewrite → Allgemein** → "Alle Caches generieren". Or in code: `rex_yrewrite::generatePathFile([])`
+- There is currently **no** API endpoint for cache refresh.
+
+## Article metainfo
+
+Set custom metainfos (`art_*`, `cat_*`, `med_*`, `clang_*`) via the metainfo value endpoints:
+
+```
+PUT /api/structure/articles/{id}/metainfo
+{ "art_color": "blue", "art_layout": "wide" }
+```
+
+Field definitions are managed via `/api/metainfo/fields` (admin-only when called via `BackendUser`; via Bearer the token needs the `metainfo/fields/*` scopes).
 
 ## OpenAPI spec
 
@@ -148,8 +185,8 @@ Available in the backend at `?page=api/openapi`. Generated from the route defini
 
 ## Common pitfalls
 
-- Calling `POST /api/structure/articles` without the trailing slash – 401 "Route with method not found". The matcher cares.
-- Adding a scope to the token that doesn't quite match the route name (e.g. `structure/article/add` vs. `structure/articles/add`) – 401 "Authorization failed".
-- `Authorization` header missing on Apache – add the `RewriteRule` above.
-- Building tooling that posts a slice and expects the article to be reachable on the frontend immediately – regenerate yrewrite path cache after creating articles/categories.
-- Reading the swallowed-exception 401 as "wrong token" – check the system log first; lots of 401s are actually 500s in disguise.
+- Adding a scope to the token that doesn't quite match the route name (e.g. `structure/article/add` vs. `structure/articles/add`) → 401 `Authorization failed`. Copy from the route source, don't re-type.
+- Calling a Bearer route via the cookie session (or vice versa) → use the `/api/backend/...` mirror for backend-session calls, the plain path for Bearer.
+- Building tooling that posts a slice and expects the article to be reachable on the frontend immediately → regenerate yrewrite path cache after creating articles/categories.
+- 500 with no log line: check that `rex_logger` is configured and writeable; the addon logs every controller exception.
+- `Authorization` header missing on Apache → add the `RewriteRule` above.


### PR DESCRIPTION
## Summary

Aligns the `redaxo-api-addon` plugin with the [api addon 1.2 release](https://github.com/FriendsOfREDAXO/api/releases/tag/1.2). The skills shipped with the plugin describe the v1.1 surface — many of the warnings ("Known bugs as of v1.1", trailing-slash quirks, "Two 401 messages") are now stale, and a large set of new endpoints (Metainfo, User-Roles, Slice-CRUD, Media-Upload, Backend-mirror under `/api/backend/...`) wasn't documented at all.

### `api-routes/SKILL.md`

- New route table grouped by resource: Structure (incl. PUT updates and full slice CRUD), Templates / Modules / Clangs CRUD, Media (incl. multipart upload + `/file` + `/info` + categories CRUD), Users (incl. role assignment + role CRUD), Metainfo fields + per-resource values (Articles/Categories/Media/Clangs), and the Backend-mirror routes under `/api/backend/...`.
- Replaced the "Two 401 messages" matrix with the actual 401 / 404 / 405 / 500 set. `RouteCollection::handle()` now distinguishes `Route not found`, `Method not allowed` (with `allowed[]`), `Authorization failed`, and `Internal server error` (with `message`).
- Removed the "Trailing-slash quirks" section — articles list/add now both live on the no-slash path in 1.2.
- Removed the "Known bugs (as of v1.1)" section — `name`-filter bug, `LIMIT`-binding bug, "Headers already sent", missing article metainfo, missing media upload — all fixed in 1.2.
- Added the unified `{data, meta}` list response format with `page` / `per_page` / `sort` semantics (including the `per_page` cap of 1000).

### `api-extending/SKILL.md`

- Switched response examples from `new Response(json_encode(...))` to `JsonResponse` — that's the addon's convention since #18.
- Documented the `Body` schema key for POST/PUT routes (alongside `query`), with `RouteCollection::getQuerySet()` for validation.
- Documented the actual error behaviour: `RouteCollection` already wraps unhandled throwables with `rex_logger::logException` and returns structured 500 — so the previous "exceptions get swallowed" framing is wrong.
- **New caveat** (the central gotcha from the 1.2 audit): some PRE-Extension-Points (`SLICE_UPDATE`, `SLICE_DELETE`, ...) call `rex::requireUser()` internally. Calling those service methods from a Bearer route throws because `rex::getUser()` is `null` outside the backend session. Documented both workarounds: guard with `null !== rex::getUser()`, or replicate the SQL + POST-EP yourself the way `Structure::handleUpdateArticleSlice` / `handleDeleteArticleSlice` do.
- Pointed at the `Backend/*` package pattern (e.g. `lib/RoutePackage/Backend/Clangs.php`) as a reference for mirroring Bearer routes under `BackendUser`.
- Added a "Mirror REDAXO-core behaviour exactly" section — the hard rule from the addon's `CLAUDE.md` (same EP names, same parameter keys, same order, same cache invalidation, no invented EPs).

### Plugin metadata

- `plugin.json`: `0.1.0` → `0.2.0`, description extended (multipart upload, roles, metainfo, backend session).
- `README.md`: skill summaries refreshed, "tracks 1.2+" note.

## Test plan

- [ ] Manually load both skills via `/plugin install redaxo-api-addon@redaxo-marketplace` (after merge) and re-test a known prompt that previously surfaced stale advice (e.g. "the `name` filter on `/api/structure/articles` is broken" — should no longer be claimed)
- [ ] Smoke-test the new endpoints documented in the route table against a 1.2 install
- [ ] Verify the OpenAPI generator at `?page=api/openapi` matches the route table

🤖 Generated with [Claude Code](https://claude.com/claude-code)