### PR TITLE
fix(redaxo-metainfo-fields): rex_metainfo_add_field-Signatur und type_id-Tabelle korrigieren

### DIFF
--- a/plugins/redaxo-core/skills/redaxo-metainfo-fields/SKILL.md
+++ b/plugins/redaxo-core/skills/redaxo-metainfo-fields/SKILL.md
@@ -42,9 +42,28 @@ $params = 'SELECT id, name FROM ' . rex::getTable('team_role') . ' ORDER BY name
 
 The first column becomes the option key, the second becomes the label.
 
+## Function signature
+
+`rex_metainfo_add_field()` has a non-obvious parameter order — the target table is **derived from the field name's prefix** (`art_*` → articles, `cat_*` → categories, `med_*` → media, `clang_*` → languages), there's no explicit table argument.
+
+```php
+rex_metainfo_add_field(
+    string  $title,         // backend label
+    string  $name,          // column name WITH prefix, e.g. 'cat_in_navi_top'
+    int     $priority,      // display order in the backend form
+    string  $attributes,    // raw input attributes, e.g. 'class="form-control"'
+    int     $type,          // type_id — see table below
+    string  $default,       // default value (still a string)
+    ?string $params   = null, // SELECT/RADIO/CHECKBOX options OR a SELECT-query
+    ?string $validate = null,
+    string  $restrictions = '',
+    ?string $callback = null,
+);
+```
+
 ## Idempotent setup pattern
 
-`rex_metainfo_add_field()` only **adds** — it doesn't update an existing field. For setup scripts that should be safe to re-run:
+`rex_metainfo_add_field()` only **adds** — it silently no-ops if a field with that name already exists, and it doesn't update `params`/`default`/etc. on subsequent runs. For setup scripts that should be safe to re-run:
 
 ```php
 $tableName = rex::getTable('metainfo_field');
@@ -55,17 +74,16 @@ $existing  = rex_sql::factory()->getArray(
 
 if (empty($existing)) {
     rex_metainfo_add_field(
-        'cat_in_navi_top',                      // name
-        'In top navi',                          // label
-        7,                                      // type_id (7 = SELECT)
-        ':–|1:Ja',                              // params
-        '',                                     // default
-        '',                                     // validate
-        '',                                     // restrictions
-        rex_metainfo_category_handler::PREFIX   // category prefix
+        'In top navi',         // $title (backend label)
+        'cat_in_navi_top',     // $name (must start with cat_/art_/med_/clang_)
+        100,                   // $priority
+        '',                                  // $attributes
+        rex_metainfo_default_type::SELECT,   // $type
+        '',                                  // $default
+        ':–|1:Ja',             // $params (option list)
     );
 } elseif ($existing[0]['params'] !== ':–|1:Ja') {
-    // UPDATE the row directly to fix params on existing field
+    // UPDATE the row directly to fix params on an existing field
     rex_sql::factory()
         ->setTable($tableName)
         ->setWhere(['id' => $existing[0]['id']])
@@ -97,21 +115,20 @@ $nav->get(0, 1, true, true);
 
 ## Type IDs reference
 
-| `type_id` | Field type |
-|---|---|
-| 1 | Text |
-| 2 | Textarea |
-| 3 | Legend (display only) |
-| 4 | Select (single) |
-| 5 | Radio |
-| 6 | Checkbox |
-| 7 | Select (with multiple support) |
-| 8 | Date |
-| 9 | Datetime |
-| 10 | Time |
-| 11 | REX_MEDIA_BUTTON |
-| 12 | REX_MEDIALIST_BUTTON |
-| 13 | REX_LINK_BUTTON |
-| 14 | REX_LINKLIST_BUTTON |
+Source of truth: `rex_metainfo_default_type` (`addons/metainfo/lib/default_type.php`). Prefer the constants over the raw integers — they survive any future re-ordering.
 
-Use `rex_metainfo_table_expander::PREFIX` for media metainfo and the matching constants for article/category/clang.
+| `type_id` | Constant | Field type |
+|---|---|---|
+| 1 | `rex_metainfo_default_type::TEXT` | Text |
+| 2 | `rex_metainfo_default_type::TEXTAREA` | Textarea |
+| 3 | `rex_metainfo_default_type::SELECT` | Select |
+| 4 | `rex_metainfo_default_type::RADIO` | Radio |
+| 5 | `rex_metainfo_default_type::CHECKBOX` | Checkbox |
+| 6 | `rex_metainfo_default_type::REX_MEDIA_WIDGET` | Media picker (single) |
+| 7 | `rex_metainfo_default_type::REX_MEDIALIST_WIDGET` | Media picker (multi) |
+| 8 | `rex_metainfo_default_type::REX_LINK_WIDGET` | Link picker (single) |
+| 9 | `rex_metainfo_default_type::REX_LINKLIST_WIDGET` | Link picker (multi) |
+| 10 | `rex_metainfo_default_type::DATE` | Date |
+| 11 | `rex_metainfo_default_type::DATETIME` | Datetime |
+| 12 | `rex_metainfo_default_type::LEGEND` | Legend (display-only separator) |
+| 13 | `rex_metainfo_default_type::TIME` | Time |


### PR DESCRIPTION
## Problem

Der Skill enthielt zwei voneinander unabhängige Halluzinationen, die zu **vollständig kaputtem User-Code** geführt hätten:

1. **Falsche Funktions-Signatur.** Das Code-Beispiel im idempotenten Setup-Pattern rief `rex_metainfo_add_field()` mit 8 Parametern in erfundener Reihenfolge auf (`name, label, type_id, params, default, validate, restrictions, PREFIX`). Die echte Signatur in `redaxo/src/addons/metainfo/functions/function_metainfo.php` hat **10 Parameter** in der Reihenfolge `(title, name, priority, attributes, type, default, params, validate, restrictions, callback)`. Die Ziel-Tabelle wird **aus dem Spaltennamen-Präfix abgeleitet** (`art_*`, `cat_*`, `med_*`, `clang_*`), nicht als Parameter übergeben.
2. **Falsche type_id-Tabelle.** Die Zuordnungen waren komplett verschoben (z. B. „3 = Legend", „6 = Checkbox", „11 = REX_MEDIA_BUTTON"). Die echten Konstanten in `rex_metainfo_default_type` sind `1=TEXT`, `2=TEXTAREA`, `3=SELECT`, `4=RADIO`, `5=CHECKBOX`, `6=REX_MEDIA_WIDGET`, `7=REX_MEDIALIST_WIDGET`, `8=REX_LINK_WIDGET`, `9=REX_LINKLIST_WIDGET`, `10=DATE`, `11=DATETIME`, `12=LEGEND`, `13=TIME`. Auch der Suffix war falsch (`_BUTTON` statt `_WIDGET`).

## Lösung

- Neue Sektion `## Function signature` mit der echten 10-Parameter-Signatur und der Erklärung, dass das Ziel aus dem Namens-Präfix abgeleitet wird.
- Code-Beispiel im Idempotent-Setup auf die korrekte Reihenfolge umgebaut und auf die typsichere Konstante `rex_metainfo_default_type::SELECT` umgestellt.
- Type-IDs-Tabelle gegen die echten Werte aus `rex_metainfo_default_type` ausgetauscht, mit Verweis auf die Source und Empfehlung, die Konstante statt der Zahl zu nutzen.

Verifiziert gegen `redaxo/redaxo` Branch `5.x`:
- `redaxo/src/addons/metainfo/lib/default_type.php`
- `redaxo/src/addons/metainfo/functions/function_metainfo.php`