### PR TITLE
docs(ycom-extension-points): YCom-Tippfehler 'abtract' explizit kennzeichnen

### DIFF
--- a/plugins/redaxo-ycom/skills/ycom-extension-points/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-extension-points/SKILL.md
@@ -56,6 +56,8 @@ Lower priority numbers run first. OTP runs before password change so a stale pas
 
 ### Custom injection
 
+The abstract base class is — verbatim, including the missing `s` — `rex_ycom_injection_abtract`. The typo is in the YCom source (`plugins/auth/lib/injections/abstract.php`), not in this skill. Use it as-is; `rex_ycom_injection_abstract` does not exist and would throw a fatal error.
+
 ```php
 class my_injection extends rex_ycom_injection_abtract {
     public function getRewrite(): bool|string {


### PR DESCRIPTION
## Problem

Im Custom-Injection-Beispiel steht `class my_injection extends rex_ycom_injection_abtract` (ohne `s`). Das sieht wie ein Tippfehler im Skill aus — eine reflexartige Korrektur zu `rex_ycom_injection_abstract` führt aber zu einem Fatal Error, weil die Klasse im YCom-Source selbst falsch geschrieben ist (`plugins/auth/lib/injections/abstract.php`, Klassendeklaration `abstract class rex_ycom_injection_abtract`).

## Lösung

Eine kurze Zeile vor dem Code-Beispiel ergänzt, die den Tippfehler als YCom-Original kennzeichnet und ausdrücklich davor warnt, den Namen zu „korrigieren". Verifiziert gegen `yakamara/redaxo_ycom@main`.