### PR TITLE
docs(ycom-tokens): vierten Pipe-Slot direkt bei der Syntax dokumentieren

### DIFF
--- a/plugins/redaxo-ycom/skills/ycom-tokens/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-tokens/SKILL.md
@@ -27,6 +27,8 @@ ycom_user_token|token|validate|type|error_message
 - `create` – generates a token, stores it on the matched user, and exposes it as `REX_YFORM_DATA[field=token]` for the email template
 - `validate` – consumes a token from the URL; on success, the matching user becomes the current dataset (and is logged in for `login` and `password_reset` types)
 
+> **Fourth slot in `create` is documentation, not configuration.** Despite the `email_field` label, the `create` branch reads `value_pool['sql']['email']` directly — the slot is ignored at runtime. Always name the email form field literally `email`, regardless of what you put in the fourth slot.
+
 ## Direct login via token
 
 ### Article A — token generation form
@@ -88,7 +90,7 @@ ycom_user_token|token|create|register|email
 action|tpl2email|register_confirm|email|
 ```
 
-Important: the form **must contain a field literally named `email`**. The `create` branch of `ycom_user_token` reads from `value_pool['sql']['email']` directly — the fourth pipe slot is documented as `email_field` for clarity but is not evaluated by the current implementation. So: name the email field `email`, full stop.
+Important: the form must contain a field literally named `email` (see "Field syntax" above for why the fourth pipe slot doesn't help here).
 
 Confirmation:
 


### PR DESCRIPTION
## Problem

Der `create`-Zweig von `ycom_user_token` liest hartkodiert aus `value_pool['sql']['email']` — der vierte Pipe-Slot (`email_field`) ist nur ein Doku-Hinweis und wird zur Laufzeit ignoriert. Das stand bisher nur

- versteckt am Ende der Registration-Recipe (Z91),
- und nochmal als letzter Pitfall (Z105).

Wer den Skill von oben überfliegt und beim Abschnitt „Field syntax" abbricht, schreibt eine eigene Variante wie `ycom_user_token|token|create|register|my_mail_field` und stolpert dann über `email not found`.

## Lösung

- Hinweis als Blockquote direkt unter „Field syntax" platziert, damit er gesehen wird bevor jemand das eigene Recipe baut.
- Die wortgleiche Wiederholung im Registration-Block durch eine kurze Rückverweis-Zeile ersetzt.
- Der Pitfall bleibt unverändert.