### PR TITLE
docs(structure-categories): Verweis auf yrewrite-domains beim mountId-Pitfall

### DIFF
--- a/plugins/redaxo-structure/skills/structure-categories/SKILL.md
+++ b/plugins/redaxo-structure/skills/structure-categories/SKILL.md
@@ -152,5 +152,5 @@ For frontend navigation, `isOnline()` is enough – the structure addon already 
 - Building the active-state check by string-comparing names instead of IDs – breaks when categories share a name.
 - Generating a navigation tree with thousands of categories without caching – every page render walks the full tree.
 - Forgetting `isOnline()` on each level – offline parents whose children are online become reachable via direct URL but not from the menu.
-- Hardcoding category IDs in templates instead of using `rex_yrewrite::getCurrentDomain()->getMountId()` for "below this domain's root".
+- Hardcoding category IDs in templates instead of using `rex_yrewrite::getCurrentDomain()->getMountId()` for "below this domain's root". On multi-domain sites see the yrewrite-domains skill for the full domain-rooted navigation pattern.
 - Calling `getChildren()` without the `$ignore_offlines = true` flag in a public template, then leaking offline categories into navigation.


### PR DESCRIPTION
## Problem

Der Pitfall „Hardcoding category IDs ... use rex_yrewrite::getCurrentDomain()->getMountId()" empfiehlt einen YRewrite-Call, erklärt aber nicht wo Multi-Domain-Setups die zugehörige Domain-→-Kategorie-Verdrahtung dokumentiert finden. Wer hier landet, übernimmt die Code-Zeile ohne den Kontext aus dem `yrewrite-domains`-Skill.

## Lösung

Eine Zeile am Pitfall angehängt, die auf den `yrewrite-domains`-Skill zeigt. Kein Inhalt verschoben — der Cross-Link macht den Pitfall self-contained.