### PR TITLE
docs(rex-create-addon): Description um deutsche Trigger und Modul-Abgrenzung ergänzen

### DIFF
--- a/plugins/redaxo-core/skills/rex-create-addon/SKILL.md
+++ b/plugins/redaxo-core/skills/rex-create-addon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rex-create-addon
-description: Scaffold a complete REDAXO addon skeleton with package.yml, boot.php, install/uninstall, lang files, and an optional backend page. Creates real files in redaxo/src/addons/. Invoke as /redaxo-core:rex-create-addon when the user wants a new addon scaffolded.
+description: Scaffold a complete REDAXO addon skeleton — package.yml, boot.php, install/uninstall.php, lang files, optional backend page — under redaxo/src/addons/. Distinct from rex-create-module (which scaffolds a single content module). Invoke as /redaxo-core:rex-create-addon when the user wants a new addon scaffolded, says "neues Addon", "Addon erstellen", "Addon-Gerüst", "Addon erzeugen", or asks "how do I start a new REDAXO addon".
 ---
 
 You are scaffolding a complete REDAXO addon under `redaxo/src/addons/`.


### PR DESCRIPTION
## Problem

Die Description nannte ausschließlich englische Trigger („wants a new addon scaffolded") und grenzte nicht gegen `rex-create-module` ab. In der Praxis:

- Wer auf Deutsch „neues Addon erstellen" tippt, hatte keine Trigger-Wörter dafür — der Skill wurde nicht zuverlässig aktiviert.
- Wenn nur „Addon" fiel, sprang gelegentlich `rex-create-module` an (das eigentlich für Content-Module gedacht ist), weil beide ähnlich klingen.

## Lösung

- Deutsche Phrasen ergänzt: „neues Addon", „Addon erstellen", „Addon-Gerüst", „Addon erzeugen".
- Einen kurzen Halbsatz zur Abgrenzung zu `rex-create-module` aufgenommen.
- Body und Skill-Logik unverändert.