### PR TITLE
docs(yform-fields): deutsche Trigger-Phrasen in der Description

### DIFF
--- a/plugins/redaxo-yform/skills/yform-fields/SKILL.md
+++ b/plugins/redaxo-yform/skills/yform-fields/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yform-fields
-description: YForm field types, validators, and actions – the building blocks for forms and tables. Covers all value/validate/action types with parameters, the choice / be_manager_relation / upload field configurations, custom field types, and the pipe syntax used in the Formbuilder. Use when picking field types, configuring validators, building custom field/validator classes, troubleshooting field rendering or save behavior, or writing forms in pipe syntax.
+description: YForm field types, validators, and actions – the building blocks for forms and tables. Covers all value/validate/action types with parameters, the choice / be_manager_relation / upload field configurations, custom field types, and the pipe syntax used in the Formbuilder. Use when picking field types, configuring validators, building custom field/validator classes, troubleshooting field rendering or save behavior, writing forms in pipe syntax, or when the user says "Feldtypen", "YForm-Felder", "Validierung", "Formular-Felder", "be_manager_relation", or "Formbuilder Pipe-Syntax".
 ---
 
 # YForm Fields, Validators & Actions


### PR DESCRIPTION
## Problem

Die Description bestand komplett aus englischen Trigger-Wörtern. Deutsche Anfragen wie „welche Feldtypen gibt es", „YForm-Validierung", „Formular-Felder" oder „Formbuilder Pipe-Syntax" haben den Skill nicht aktiviert.

## Lösung

Liste mit deutschen Schlüsselbegriffen am Ende der Description ergänzt: „Feldtypen", „YForm-Felder", „Validierung", „Formular-Felder", „be_manager_relation", „Formbuilder Pipe-Syntax". Body unverändert.