### PR TITLE
docs(yform-rest-api): deutsche Trigger-Phrasen in der Description

### DIFF
--- a/plugins/redaxo-yform/skills/yform-rest-api/SKILL.md
+++ b/plugins/redaxo-yform/skills/yform-rest-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yform-rest-api
-description: YForm's built-in REST API – exposing YForm tables as JSON:API endpoints. Covers route registration via rex_yform_rest_route, GET filter/include/order/pagination params, JSON:API POST bodies, DELETE, token-based authentication, and CORS headers. Use when the user exposes a YForm table as a REST endpoint, configures token auth, customizes per-method field whitelists, or builds a frontend SPA that calls a YForm-backed API.
+description: YForm's built-in REST API – exposing YForm tables as JSON:API endpoints. Covers route registration via rex_yform_rest_route, GET filter/include/order/pagination params, JSON:API POST bodies, DELETE, token-based authentication, and CORS headers. Use when the user exposes a YForm table as a REST endpoint, configures token auth, customizes per-method field whitelists, builds a frontend SPA that calls a YForm-backed API, or says "REST-Endpoint", "JSON-API", "Token-Auth", "API-Aufrufe", "Endpunkt für YForm-Tabelle".
 ---
 
 # YForm REST API


### PR DESCRIPTION
## Problem

Description war ausschließlich englisch — Anfragen wie „REST-Endpoint bauen", „JSON-API für YForm-Tabelle", „Token-Auth einrichten" haben den Skill nicht zuverlässig aktiviert.

## Lösung

Schlüsselbegriffe ergänzt: „REST-Endpoint", „JSON-API", „Token-Auth", „API-Aufrufe", „Endpunkt für YForm-Tabelle". Body unverändert.