### PR TITLE
docs(multiglossar-replacement-engine): Parser-Klasse als intern kennzeichnen

### DIFF
--- a/plugins/redaxo-multiglossar/skills/multiglossar-replacement-engine/SKILL.md
+++ b/plugins/redaxo-multiglossar/skills/multiglossar-replacement-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multiglossar-replacement-engine
-description: MultiGlossar replacement engine internals - boot.php OUTPUT_FILTER hook, MultiGlossar\\Parser in lib/glossar/multiglossar.php, DOMDocument parsing, text_replace regex matching, replace_definition template placeholders, and URL namespace resolution via Url\\Profile/url_generator_profile. Use when the user debugs missing replacements, broken tooltip HTML, URL addon integration, or replacement performance.
+description: MultiGlossar replacement engine internals - boot.php OUTPUT_FILTER hook, the (internal) MultiGlossar\\Parser in lib/glossar/multiglossar.php, DOMDocument parsing, text_replace regex matching, replace_definition template placeholders, and URL namespace resolution via Url\\Profile/url_generator_profile. Stable integration is via OUTPUT_FILTER and the addon config — Parser is not a public API. Use when the user debugs missing replacements, broken tooltip HTML, URL addon integration, or replacement performance.
 ---
 
 # MultiGlossar Replacement Engine
@@ -19,6 +19,8 @@ Frontend replacement is executed in `boot.php` via `rex_extension::register('OUT
 This architecture avoids raw global string replacement and limits changes to parsed text nodes.
 
 ## Parser and DOM behavior
+
+> `MultiGlossar\Parser` is **internal**. Don't construct or call it from your own code — the stable integration points are the `OUTPUT_FILTER` hook (which the addon already registers) and the addon's config. The methods below are documented so you can read along when debugging, not as an API to invoke.
 
 Key parser methods:
 


### PR DESCRIPTION
## Problem

Der Skill listet Parser-Methoden (`init_dom`, `parse_dom`, `text_replace`, …) im Abschnitt „Parser and DOM behavior", ohne irgendwo zu sagen, dass `MultiGlossar\\Parser` eine interne Klasse ist. Ein flüchtiger Leser könnte annehmen, das seien stabile Einstiegspunkte und sie direkt aus eigenem Code aufrufen. Damit wären Refactorings im Addon ein Bruch des User-Codes.

## Lösung

- Blockquote vor der Methoden-Auflistung: Parser ist intern, stabile Integration läuft über `OUTPUT_FILTER` und die Addon-Config.
- Description um den gleichen Hinweis ergänzt (Trigger-Keywords bleiben drin, damit Auto-Triggering bei Debug-Anfragen weiter funktioniert).