### PR TITLE
docs(ycom-quickstart): Idempotenz-Bedingung im Pre-flight statt am Ende

### DIFF
--- a/plugins/redaxo-ycom/skills/ycom-quickstart/SKILL.md
+++ b/plugins/redaxo-ycom/skills/ycom-quickstart/SKILL.md
@@ -43,6 +43,8 @@ RewriteCond %{HTTP:Authorization} .
 RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 ```
 
+> **Idempotency contract.** Re-running this recipe is safe **as long as you reuse the original article IDs**. Steps 2 and 3 always need a stable ID map; step 1 only needs one if you want to skip the structure-create. After step 1 finishes, persist `$LOGIN`, `$REGISTER`, … into `.ycom-quickstart-state.json` (snippet at the bottom under "Idempotency") and source it on every subsequent run. Without that file, step 1 will happily create duplicate articles named "Login (2)" etc.
+
 ## Step 1 — Create the structure via the api addon
 
 The 9 pages are not a flat list. The 6 user-facing entry points (login, password-forgot, profile, password-change, registration, logout) are **categories** at the top level; the 3 token-target pages (registration-confirm, password-reset, terms-of-use) live as **articles inside the related category**:


### PR DESCRIPTION
## Problem

Der Skill ist 462 Zeilen lang. Die Sektion „Idempotency" steht auf Zeile 426 — also nachdem du Step 1 (Struktur anlegen), Step 2 (Slices) und Step 3 (Config + Mail-Templates) schon einmal ausgeführt hast. Ohne diesen Hinweis startet der zweite Lauf damit, ein zweites „Login (2)", „Logout (2)" usw. neben den bestehenden Kategorien anzulegen.

Im Intro steht zwar „Idempotent.", aber die Bedingung dafür („nur wenn du die Artikel-IDs aus dem ersten Lauf wiederverwendest") wird erst ganz unten ausgesprochen.

## Lösung

Eine kurze Blockquote-Notiz direkt nach dem Pre-flight-Abschnitt: Idempotenz-Vertrag in einem Satz erklärt, plus Aufforderung das `.ycom-quickstart-state.json` nach Step 1 zu schreiben und auf jedem Folgerun zu sourcen. Verweis auf die vorhandene „Idempotency"-Sektion am Ende für das Snippet — nichts dupliziert.