### PR TITLE
Add redaxo-url plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     "email": "info@redaxo.org"
   },
   "metadata": {
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {
@@ -44,6 +44,18 @@
         "name": "Friends Of REDAXO"
       },
       "homepage": "https://github.com/yakamara/redaxo_yrewrite",
+      "license": "MIT"
+    },
+    {
+      "name": "redaxo-url",
+      "source": "./plugins/redaxo-url",
+      "description": "URL addon: dataset-driven pretty URLs, profiles, URL_PRE_SAVE hooks, frontend resolution, programmatic rebuilds",
+      "category": "cms",
+      "tags": ["redaxo", "url", "pretty-urls", "seo", "routing"],
+      "author": {
+        "name": "Friends Of REDAXO"
+      },
+      "homepage": "https://github.com/tbaddade/redaxo_url",
       "license": "MIT"
     },
     {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add addon-specific plugins based on what your project uses:
 ```bash
 /plugin install redaxo-yform@redaxo-marketplace
 /plugin install redaxo-yrewrite@redaxo-marketplace
+/plugin install redaxo-url@redaxo-marketplace
 /plugin install redaxo-structure@redaxo-marketplace
 /plugin install redaxo-mform@redaxo-marketplace
 /plugin install redaxo-multiglossar@redaxo-marketplace
@@ -38,6 +39,7 @@ Add addon-specific plugins based on what your project uses:
 | `redaxo-yform`        | YForm tables, datasets (YOrm), field/validate/action reference, frontend forms, email templates, REST API                                               | If `yform` is installed                   |
 | `redaxo-mform`        | Module input forms with `MForm::factory()`, flex repeaters, custom-link/imagelist/colorswatch widgets, output helpers, MForm-provided YForm value types | If `mform` is installed                   |
 | `redaxo-yrewrite`     | Domains, pretty URLs, redirects, multi-language SEO                                                                                                     | If `yrewrite` is installed                |
+| `redaxo-url`          | URL addon: dataset-driven pretty URLs, profiles, `URL_PRE_SAVE` hooks, frontend resolution, programmatic rebuilds                                        | If `url` is installed                     |
 | `redaxo-ycom`         | Frontend user auth, login/registration/password forms, groups, media protection, OTP/2FA, tokens, SAML/OAuth2/CAS                                       | If `ycom` is installed                    |
 | `redaxo-api-addon`    | FriendsOfRedaxo/api – Bearer-token REST API for articles/categories/slices/modules/templates/media                                                      | If you call (or extend) the `api` addon   |
 | `redaxo-search-it`    | Full-text search, indexing, search modules, highlighting, autocomplete, similarity search, extension points                                             | If `search_it` is installed               |

--- a/plugins/redaxo-url/.claude-plugin/plugin.json
+++ b/plugins/redaxo-url/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "redaxo-url",
+  "version": "0.1.0",
+  "description": "URL addon support for Claude Code: dataset-driven pretty URLs, profile setup, URL_PRE_SAVE hooks, and frontend resolution via Url::resolveCurrent()",
+  "author": {
+    "name": "Friends Of REDAXO"
+  },
+  "homepage": "https://github.com/tbaddade/redaxo_url",
+  "repository": "https://github.com/FriendsOfREDAXO/claude-marketplace",
+  "license": "MIT",
+  "keywords": ["redaxo", "url", "pretty-urls", "seo", "routing", "datasets"]
+}

--- a/plugins/redaxo-url/README.md
+++ b/plugins/redaxo-url/README.md
@@ -1,0 +1,22 @@
+# redaxo-url
+
+Claude Code plugin for the [URL addon](https://github.com/tbaddade/redaxo_url) by Thomas Blum.
+
+The URL addon generates dataset-driven pretty URLs from any YForm table — e.g. turning a `rex_yf_products` row into `www.example.com/products/my-product/` without touching REDAXO's article structure.
+
+## What this plugin covers
+
+| Skill | Activates when… |
+|---|---|
+| `url-generator-profiles` | You configure a URL profile, map a YForm table to an article, or debug generated URLs |
+| `url-generator-hooks` | You use `URL_PRE_SAVE` to shorten paths, `URL_PROFILE_RESTRICTION` to filter datasets |
+| `url-generator-frontend` | You resolve the current dataset in a module via `Url::resolveCurrent()` |
+| `url-generator-rebuild` | You (re)generate URLs from PHP — setup scripts, migrations, or a profile that stays empty |
+
+## Install
+
+```bash
+/plugin install redaxo-url@redaxo-marketplace
+```
+
+Requires `yrewrite` and `url` addons to be installed in your REDAXO project.

--- a/plugins/redaxo-url/skills/url-generator-frontend/SKILL.md
+++ b/plugins/redaxo-url/skills/url-generator-frontend/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: url-generator-frontend
+description: Resolving the current dataset in a REDAXO module or template using the URL addon – Url::resolveCurrent(), reading dataset values, detecting active profile namespace. Use when the user writes a module that should display different content depending on which brand/product URL is currently open, checks Url::resolveCurrent() return value, or asks how to detect the active URL namespace.
+---
+
+# URL Generator – Frontend Resolution
+
+When a visitor opens a generated URL (e.g. `/acme/`), the URL addon routes the request to the profile's `article_id`. The module on that article needs to detect *which* dataset is active.
+
+## Url::resolveCurrent()
+
+```php
+use Url\Url;
+
+$manager = Url::resolveCurrent();
+
+if ($manager === null) {
+    // No URL addon URL matched — regular article, show overview
+}
+```
+
+`resolveCurrent()` looks up the current request URL in `rex_url_generator_url` and returns a `UrlManager` instance (or `null` if no match).
+
+## Checking the active profile namespace
+
+Each profile has a `namespace` (set in the backend, e.g. `brands`). Use this to distinguish multiple profiles routing to the same article:
+
+```php
+if ($manager->getProfile()->getNamespace() === 'brands') {
+    // brand detail view
+}
+```
+
+Or check by profile ID:
+```php
+if ($manager->getProfile()->getId() === 1) { ... }
+```
+
+## Reading dataset values
+
+```php
+$datasetId = $manager->getDatasetId(); // = data_id in rex_url_generator_url
+
+// Load the dataset. Any YForm table works via the generic API; a project with
+// its own model class can use that instead.
+$dataset = rex_yform_manager_dataset::get($datasetId, 'rex_yf_brands');
+if ($dataset === null) {
+    // Row deleted after URL was generated
+    rex_response::setStatus(rex_response::HTTP_NOT_FOUND);
+    exit;
+}
+```
+
+## Typical module output.php pattern
+
+```php
+use Url\Url;
+
+if (rex::isBackend()) {
+    echo '<div class="alert alert-info">Brand output: detail or overview view.</div>';
+    return;
+}
+
+$manager = Url::resolveCurrent();
+
+if ($manager !== null && $manager->getProfile()->getNamespace() === 'brands') {
+    // Detail view
+    $dataset = rex_yform_manager_dataset::get($manager->getDatasetId(), 'rex_yf_brands');
+    if (!$dataset) { rex_response::setStatus(rex_response::HTTP_NOT_FOUND); exit; }
+
+    $fragment = new rex_fragment();
+    $fragment->setVar('brand', $dataset, false);
+    echo $fragment->parse('brandView.php');
+} else {
+    // Overview
+    $fragment = new rex_fragment();
+    $fragment->setVar('model', rex_yform_manager_dataset::query('rex_yf_brands')->find(), false);
+    echo $fragment->parse('brandListView.php');
+}
+```
+
+## Common pitfalls
+
+**`resolveCurrent()` returns null on the detail article** — The URL addon only resolves if a generated URL in `rex_url_generator_url` matches the current request. If URLs were not regenerated after the profile was created, there are no entries to match. Regenerate from the backend.
+
+**Wrong article handles the request** — `article_id` in `rex_url_generator_url` must point to the article carrying the detail module. If it points to the overview article, `resolveCurrent()` will return a manager but the wrong module runs. Check with:
+```sql
+SELECT url, article_id FROM rex_url_generator_url WHERE profile_id = 1 LIMIT 5;
+```
+
+**The overview article must not be the same as the detail article** — If the module on article X is supposed to show both overview and detail, the URL addon must route detail URLs to article X. Using the overview article for URL generation base (to get root-level URLs) and then having `article_id` in the url table point to the detail article is the correct setup (see `url-generator-hooks`).

--- a/plugins/redaxo-url/skills/url-generator-hooks/SKILL.md
+++ b/plugins/redaxo-url/skills/url-generator-hooks/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: url-generator-hooks
+description: URL addon extension points in REDAXO – URL_PRE_SAVE to shorten or modify generated URLs before they are stored, URL_PROFILE_RESTRICTION to filter datasets, and the CLI isBackend gotcha. Use when the user wants to remove an article path prefix from URLs (e.g. domain.de/acme instead of domain.de/brand-output/acme), filter which datasets get a URL, or debugs unexpected URL regeneration from the CLI.
+---
+
+# URL Generator – Extension Point Hooks
+
+## URL_PRE_SAVE — modify a URL before it is stored
+
+Fires once per dataset row, before the URL is written to `rex_url_generator_url`. The subject is a `Url\Url` object; return a modified `Url\Url` to replace it, or `false` to skip this entry entirely.
+
+Params available via `$ep->getParams()`:
+
+| Key | Type | Value |
+|---|---|---|
+| `profile_id` | int | ID from `rex_url_generator_profile` |
+| `article_id` | int | Routing target article |
+| `clang_id` | int | Language ID |
+| `data_id` | int | Dataset primary key |
+| `profile` | `Url\Profile` | Full profile object |
+
+### Recipe: strip article path so URLs are at the domain root
+
+By default the profile article's yrewrite path is prepended to every slug. The profile article ("Brand output") has URL `/brand-output/` → brand URLs become `/brand-output/acme/`.
+
+To generate `/acme/` instead, register this hook in your project's boot file (e.g. the `theme` addon's `functions.php`) **outside** of `isBackend()` / `isFrontend()` blocks so it runs in all contexts:
+
+```php
+rex_extension::register('URL_PRE_SAVE', function (rex_extension_point $ep) {
+    $params = $ep->getParams();
+
+    // Apply only to the relevant profile (check ID in rex_url_generator_profile)
+    if (($params['profile_id'] ?? 0) !== 1) {
+        return $ep->getSubject();
+    }
+
+    /** @var \Url\Url $url */
+    $url       = $ep->getSubject();
+    $articleId = $params['article_id'];
+    $clangId   = $params['clang_id'];
+
+    $domain     = rex_yrewrite::getDomainByArticleId($articleId, $clangId);
+    $articleUrl = rex_getUrl($articleId, $clangId);
+    $startUrl   = rex_getUrl($domain->getStartId(), $clangId);
+
+    // Nothing to strip if the profile article IS the domain start article
+    if ($articleId === $domain->getStartId()) {
+        return $url;
+    }
+
+    // Remove the article path segment (handles both with and without language slug)
+    $relative = strlen($startUrl) === 1
+        ? str_replace('/' . strtolower(rex_clang::get($clangId)->getCode()) . '/', '/', $articleUrl)
+        : str_replace($startUrl, '/', $articleUrl);
+
+    $parts    = array_map('urlencode', explode('/', $relative));
+    $shortened = new \Url\Url(str_replace(implode('/', $parts), '/', $url->toString()));
+
+    // Reject duplicate URLs (two datasets normalizing to the same slug)
+    $exists = rex_sql::factory()->getArray(
+        'SELECT id FROM ' . rex::getTable('url_generator_url') . ' WHERE url = ?',
+        [$shortened->toString()]
+    );
+    if (!empty($exists)) {
+        return false;
+    }
+
+    return $shortened;
+});
+```
+
+**Important:** use `$url->toString()` — not `__toString()` (the method does not exist on `Url\Url`).
+
+This hook is the documented approach from the URL addon README.
+
+## URL_PROFILE_RESTRICTION — limit which datasets get a URL
+
+```php
+rex_extension::register('URL_PROFILE_RESTRICTION', function (rex_extension_point $ep) {
+    $params = $ep->getParams();
+    // $params['profile']  — \Url\Profile object
+    // $params['dataset']  — \rex_yform_manager_dataset
+    // Return false to skip this dataset (no URL generated)
+    $dataset = $params['dataset'];
+    if ($dataset->getValue('status') !== '1') {
+        return false;
+    }
+    return $ep->getSubject();
+});
+```
+
+## CLI gotcha: isBackend() is true in the console
+
+`redaxo/bin/console` sets `$REX['REDAXO'] = true`, so `rex::isBackend()` returns `true` even in CLI context. The URL addon registers its regeneration listeners when `isBackend() && getUser()`.
+
+`developer:sync` calls `rex_backend_login::createUser()` → a user exists → `CACHE_DELETED` fires → full URL regeneration runs.
+
+**Consequence:** running `php redaxo/bin/console cache:clear && php redaxo/bin/console developer:sync` will trigger URL regeneration — potentially before your `URL_PRE_SAVE` hook is saved to the database (developer:sync writes the hook file to DB during the same run). The result: URLs are regenerated with the original path prefix and your hook has no effect.
+
+**Fix:** always regenerate URLs from the REDAXO backend (URL addon → Generator → URLs → "Alle URLs neu generieren"), not from the CLI. Own setup scripts should set `$REX['REDAXO'] = false` to avoid inheriting backend behaviour.

--- a/plugins/redaxo-url/skills/url-generator-profiles/SKILL.md
+++ b/plugins/redaxo-url/skills/url-generator-profiles/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: url-generator-profiles
+description: URL addon (tbaddade/redaxo_url) profile setup in REDAXO – mapping a YForm table to pretty URLs via a profile article. Use when the user configures a URL profile, maps rex_yf_* tables to pretty URLs, debugs generated URLs in rex_url_generator_url, asks why brand/product URLs show the wrong path prefix, or works with the URL addon backend page.
+---
+
+# URL Generator – Profiles
+
+A **profile** maps one YForm table to pretty URLs. Each row in the table gets a URL generated from one or more column values (segments).
+
+## How it works
+
+```
+rex_url_generator_profile
+  ├── article_id      → the REDAXO article that handles detail requests
+  ├── table_name      → e.g. rex_yf_brands
+  └── table_parameters (JSON)
+        ├── column_id              → primary key column (usually id)
+        ├── column_segment_part_1  → column whose value becomes the URL slug
+        └── column_seo_title/description/image → for sitemap/meta
+
+rex_url_generator_url  (generated, do not edit by hand)
+  ├── url        → e.g. //www.example.com/brands/acme/
+  ├── article_id → routing target (same as profile.article_id)
+  ├── data_id    → primary key of the dataset row
+  └── url_hash   → SHA1(url)
+```
+
+## The article_id dual role — the most common source of confusion
+
+`profile.article_id` controls **two things at once**:
+
+1. **URL base path** — the article's yrewrite URL is prepended to the slug  
+   The profile article ("Brand output") has yrewrite URL `/brands/` → generated URL: `/brands/acme/`
+
+2. **Routing target** — incoming requests matching a generated URL are routed to this article
+
+There is no separate "routing article" setting. If you want the routing article to differ from the URL base, use the `URL_PRE_SAVE` hook (see `url-generator-hooks`).
+
+## Setting up a profile (backend)
+
+URL addon → Generator → Profiles → Add profile:
+
+- **Article**: the article that renders the detail view
+- **Table**: the YForm table (e.g. `rex_yf_brands`)
+- **Segment part 1**: column that becomes the URL slug (e.g. `name`)
+- **SEO columns**: `seo_title`, `seo_description`, `logo`
+- **Sitemap**: enable + set frequency/priority
+
+## Regenerating URLs
+
+After changing a profile, regenerate from the backend: **URL addon → Generator → URLs → "Alle URLs neu generieren"**.
+
+Do **not** trigger regeneration via CLI (`php redaxo/bin/console cache:clear`). `bin/console` sets `$REX['REDAXO'] = true`, so `rex::isBackend()` is `true` in CLI context. Combined with `developer:sync` (which calls `rex_backend_login::createUser()`), this triggers `CACHE_DELETED` and causes a full URL regeneration — potentially before your `URL_PRE_SAVE` hooks are active (see `url-generator-hooks`).
+
+## Checking what was generated
+
+```sql
+SELECT url, article_id, data_id FROM rex_url_generator_url WHERE profile_id = 1;
+```
+
+The `url` column uses `//domain/path/` format (scheme-relative). `article_id` must match the article that carries the detail module.
+
+## Getting a dataset URL in PHP
+
+```php
+// Via a dataset that exposes getUrl() (YForm models can add such a helper):
+$url = $dataset->getUrl();
+
+// Or look the generated urls up by profile namespace:
+$urls = \Url\UrlManager::getUrlsByProfile('brands');
+```
+
+## Common pitfalls
+
+**Wrong prefix in generated URLs** — The article's yrewrite URL is used as the base path. If the profile article has URL `/brand-output/`, all brand URLs get `/brand-output/acme/`. To generate root-level URLs (`/acme/`), use the `URL_PRE_SAVE` hook (see `url-generator-hooks`).
+
+**Regeneration overwrites manual DB edits** — The `rex_url_generator_url` table is fully replaced on every regeneration. Never edit it permanently by hand; configure profiles or hooks instead.
+
+**Slug encoding** — Segments are normalized with yrewrite's scheme: umlauts transliterated (`ä→ae`), spaces to hyphens, lowercased. `Weishäupl` → `weishaeupl`. `Wo & Wo` → `wo-wo`.

--- a/plugins/redaxo-url/skills/url-generator-rebuild/SKILL.md
+++ b/plugins/redaxo-url/skills/url-generator-rebuild/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: url-generator-rebuild
+description: Rebuilding URL addon urls from PHP – Profile::buildUrls()/deleteUrls(), the Cache::deleteProfiles() step, why a profile inserted via raw SQL stays empty, why UrlManagerSql::deleteAll() destroys existing urls, and the cache order that leaves a freshly created clang with zero urls. Use when the user creates URL profiles programmatically, writes a setup or migration script that must not lose existing urls, wonders why a new profile or language has no generated urls, or looks for the sitemap flags of a profile.
+---
+
+# URL Generator – Rebuilding URLs from PHP
+
+The backend button *"regenerate all urls"* is `url/pages/generator.profiles.php`.
+Its logic is the reference for every script:
+
+```php
+use Url\Profile;
+use Url\UrlManagerSql;
+
+// single profile ("refresh")
+$profile = Profile::get($id);
+$profile->deleteUrls();      // only this profile's urls
+$profile->buildUrls();
+
+// everything ("refresh_all") – see the warning below
+UrlManagerSql::deleteAll();
+foreach (Profile::getAll() as $profile) {
+    $profile->buildUrls();
+}
+```
+
+All classes live in the `Url` namespace (`Url\Profile`, `Url\Cache`,
+`Url\UrlManagerSql`, `Url\Seo`). Verified against addon version 2.2.1.
+
+## A profile inserted with raw SQL has no urls
+
+Writing a row into `rex_url_generator_profile` directly — cloning a profile for a
+new language, for instance — does **not** trigger the generator. The profile shows
+up in the backend, but `rex_url_generator_url` stays empty for it, and nothing
+warns you.
+
+Two steps are required afterwards:
+
+```php
+Url\Cache::deleteProfiles();     // profile cache is stale, getAll() would miss the new row
+foreach (Profile::getAll() as $profile) {
+    if (!in_array((int) $profile->getId(), $myNewProfileIds, true)) {
+        continue;                // leave foreign profiles alone
+    }
+    $profile->deleteUrls();
+    $profile->buildUrls();
+}
+```
+
+## Never call `UrlManagerSql::deleteAll()` in a migration
+
+It is what the backend does for *"regenerate all"*, and it is destructive: urls
+whose dataset no longer qualifies are gone for good. Observed on a live-like
+database: the count for one namespace dropped from 104 to 86 in a single run —
+18 urls that were reachable before returned 404 afterwards.
+
+If existing urls must survive, work **per profile**. `Profile::deleteUrls()` calls
+`UrlManagerSql::deleteByProfileId()` and touches nothing else.
+
+## Refresh caches *before* building, not after
+
+When a script creates clangs or changes the yrewrite domain assignment and then
+builds urls in the same request, the addon still sees the state from the start of
+the request. Symptom: the language created **last** ends up with zero urls while
+the earlier one is complete.
+
+```php
+rex_delete_cache();
+rex_clang::reset();
+rex_yrewrite::init();            // domain assignment must be current
+// only now:
+Url\Cache::deleteProfiles();
+// ... buildUrls()
+```
+
+Add a check afterwards, because the failure is silent — a profile with no urls
+whose template profile has some is a failed build, so build it a second time:
+
+```php
+$empty = rex_sql::factory()->getArray(
+    'SELECT p.id FROM ' . rex::getTable('url_generator_profile') . ' p
+       LEFT JOIN ' . rex::getTable('url_generator_url') . ' u ON u.profile_id = p.id
+      WHERE p.id IN (' . $ids . ') GROUP BY p.id HAVING COUNT(u.id) = 0');
+```
+
+## Verify by diffing, not by counting
+
+Counting urls proves that *something* was generated, not that it is correct. In a
+multi-language setup a generated url should equal the source language's url plus
+the language prefix — compare them:
+
+```
+de:  /awning-acme-model-x/
+at:  /at/awning-acme-model-x/   correct
+at:  /awning-acme-at/model-x/   prefix ended up inside the slug
+```
+
+Record the url count per profile before and after any migration and diff both the
+numbers and a sample of actual urls.
+
+## Sitemap flags live in `table_parameters`
+
+`rex_url_generator_profile` has no sitemap columns. `Profile::inSitemap()`,
+`getSitemapFrequency()` and `getSitemapPriority()` read from the JSON in
+`table_parameters`:
+
+```json
+{"sitemap_add":"1","sitemap_frequency":"always","sitemap_priority":"1.0","column_sitemap_lastmod":""}
+```
+
+Cloning a profile copies these along. Note that `sitemap_add = 1` does not by
+itself guarantee the urls appear in `sitemap.xml` — the addon registers its
+sitemap hook in `boot.php` only when `Url::getRewriter()->getSitemapExtensionPoint()`
+resolves, so verify the actual output instead of trusting the flag.


### PR DESCRIPTION
## What

Adds a plugin for the [URL addon](https://github.com/tbaddade/redaxo_url) (tbaddade/redaxo_url), which generates dataset-driven pretty URLs from YForm tables. There was no plugin for it yet, so Claude had to read the addon source to answer questions about it.

## Skills

| Skill | Covers |
|---|---|
| `url-generator-profiles` | Mapping a YForm table to pretty URLs via a profile article, debugging `rex_url_generator_url` |
| `url-generator-hooks` | `URL_PRE_SAVE` to shorten paths, `URL_PROFILE_RESTRICTION`, the CLI `isBackend()` gotcha |
| `url-generator-frontend` | Resolving the active dataset in a module via `Url::resolveCurrent()` |
| `url-generator-rebuild` | Regenerating URLs from PHP — setup scripts and migrations |

## Why the rebuild skill

The first three grew out of everyday work with the addon. The fourth came out of a production migration and documents four failure modes that are **silent** — no exception, no log entry, just missing or lost URLs that surface in the frontend later:

- A profile inserted with raw SQL never triggers the generator and stays empty. `Cache::deleteProfiles()` plus `buildUrls()` per profile is needed.
- `UrlManagerSql::deleteAll()` — what the backend's *regenerate all* button calls — permanently drops URLs whose dataset no longer qualifies. In one namespace the count went from 104 to 86; those 18 URLs returned 404 afterwards.
- Building URLs in the same request that creates a clang leaves the language created **last** with zero URLs, because the addon still sees the state from the start of the request. Refreshing `rex_delete_cache()` / `rex_clang::reset()` / `rex_yrewrite::init()` **before** building fixes it.
- Sitemap settings (`sitemap_add`, `sitemap_frequency`, `sitemap_priority`) live in the `table_parameters` JSON, not in columns of `rex_url_generator_profile`.

It also recommends verifying generated URLs by diffing them against the source language rather than counting them — a count of 86 per language looked correct while every URL had the language prefix in the wrong position.

## Verified against

url addon **2.2.1** — class namespaces (all `Url\`), method signatures (`Profile::getAll()`, `buildUrls()`, `deleteUrls()`, `Cache::deleteProfiles()`, `UrlManagerSql::deleteAll()`) and the backend's own rebuild flow in `pages/generator.profiles.php`.

Registered in `marketplace.json` and both READMEs. No existing files changed apart from those three additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mQ7PoopAKTz5FnY9E5P2N